### PR TITLE
feat: add fixed precision helpers and usd conversion

### DIFF
--- a/src/utils/fixed.ts
+++ b/src/utils/fixed.ts
@@ -1,0 +1,31 @@
+export const Q96 = 1n << 96n;
+
+/**
+ * Converts an integer value to Q64.96 fixed-point format.
+ * This is referenced as `q98` to provide a short helper
+ * for working with Q64.96 numbers.
+ */
+export function q98(value: bigint | number): bigint {
+  return BigInt(value) * Q96;
+}
+
+/**
+ * Converts a Q64.96 value back to a JavaScript number.
+ */
+export function fromQ96(value: bigint): number {
+  return Number(value) / Number(Q96);
+}
+
+/**
+ * Multiplies two Q64.96 values returning a Q64.96 result.
+ */
+export function mulQ64x96(a: bigint, b: bigint): bigint {
+  return (a * b) / Q96;
+}
+
+/**
+ * Divides two Q64.96 values returning a Q64.96 result.
+ */
+export function divQ64x96(a: bigint, b: bigint): bigint {
+  return (a * Q96) / b;
+}

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -1,0 +1,17 @@
+import { fromQ96 } from './fixed';
+
+export interface TokenInfo {
+  /** Number of decimals the token uses */
+  decimals: number;
+  /** USD price per whole token encoded as Q64.96 */
+  priceUsd: bigint;
+}
+
+/**
+ * Converts a raw token amount to a USD value using the token price.
+ */
+export function toUsd(tokenAmount: bigint, token: TokenInfo): number {
+  const amount = Number(tokenAmount) / 10 ** token.decimals;
+  const price = fromQ96(token.priceUsd);
+  return amount * price;
+}


### PR DESCRIPTION
## Summary
- add Q64.96 fixed-point helpers
- add toUsd() helper for price conversions

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e13a9560832a968b68ce3d6542b4