### PR TITLE
feat: add gas cost estimation utility

### DIFF
--- a/src/utils/gas.ts
+++ b/src/utils/gas.ts
@@ -1,0 +1,28 @@
+import { type Provider } from 'ethers';
+
+export interface EstimateGasUsdParams {
+  /** Provider for accessing network fee data */
+  provider: Provider;
+  /** Number of gas units the transaction is expected to consume */
+  gasUnits: bigint;
+  /** Current ETH price in USD for normalization */
+  ethUsd: number;
+}
+
+/**
+ * Estimates the USD cost of executing a transaction by fetching
+ * current gas fee information from the provider and converting the
+ * expected gas usage into a USD value.
+ */
+export async function estimateGasUsd(
+  { provider, gasUnits, ethUsd }: EstimateGasUsdParams
+): Promise<number> {
+  const { maxFeePerGas, gasPrice } = await provider.getFeeData();
+  const priceWei = maxFeePerGas ?? gasPrice;
+  if (!priceWei) {
+    throw new Error('Gas price data not available');
+  }
+  const wei = priceWei * gasUnits;
+  const eth = Number(wei) / 1e18;
+  return eth * ethUsd;
+}


### PR DESCRIPTION
## Summary
- add `estimateGasUsd` helper to convert gas usage to USD using provider fee data

## Testing
- `CI=1 npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6895eb91a8f8832a902eb1a5eeb64e7a