### PR TITLE
Add swap simulations with slippage guard

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ export function main(): void {
   // TODO: implement application logic
 }
 
-export { getV2Quote } from './src/core/v2';
-export { getV3Quote } from './src/core/v3';
+export { getV2Quote, simulateV2Swap } from './src/core/v2';
+export { getV3Quote, simulateV3Swap } from './src/core/v3';
 export { fetchCandidates } from './src/core/candidates';
 export default main;

--- a/src/core/sim.ts
+++ b/src/core/sim.ts
@@ -1,0 +1,9 @@
+/**
+ * Result returned by swap simulation functions.
+ */
+export interface SimResult {
+  /** Whether the swap passes the configured slippage guard */
+  ok: boolean;
+  /** Expected profit in output token terms */
+  expectedProfit: number;
+}

--- a/src/risk/slippage.ts
+++ b/src/risk/slippage.ts
@@ -1,0 +1,20 @@
+/**
+ * Checks whether the execution price stays within the allowed
+ * slippage tolerance relative to the expected price.
+ *
+ * @param expected - Reference price before executing the swap
+ * @param actual - Observed execution price
+ * @param slippageBps - Allowed slippage in basis points
+ * @returns true if the price difference is within tolerance
+ */
+export function checkSlippage(
+  expected: number,
+  actual: number,
+  slippageBps: number
+): boolean {
+  const tolerance = slippageBps / 10_000;
+  const diff = Math.abs(actual - expected) / expected;
+  return diff <= tolerance;
+}
+
+export default { checkSlippage };


### PR DESCRIPTION
## Summary
- simulate V2 and V3 swaps using pool reserves or tick shifts
- guard trades against excessive slippage
- export simulation helpers and result type

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6896650c8878832a963b736e3352b191