### PR TITLE
feat: add BPS slippage helpers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,4 +17,11 @@ export {
   submitV3Swap
 } from './src/core/v3';
 export { fetchCandidates } from './src/core/candidates';
+export {
+  checkSlippage,
+  calcMinOut,
+  computeSlippageAdjustedOut,
+  DEFAULT_SLIPPAGE_BPS,
+  DEFAULT_SLIPPAGE
+} from './src/risk/slippage';
 export default main;

--- a/src/risk/slippage.ts
+++ b/src/risk/slippage.ts
@@ -7,6 +7,11 @@
  * @param slippageBps - Allowed slippage in basis points
  * @returns true if the price difference is within tolerance
  */
+export const BPS_PER_UNIT = 10_000n;
+
+export const DEFAULT_SLIPPAGE_BPS = 50;
+export const DEFAULT_SLIPPAGE = DEFAULT_SLIPPAGE_BPS / 10_000;
+
 export function checkSlippage(
   expected: number,
   actual: number,
@@ -17,4 +22,22 @@ export function checkSlippage(
   return diff <= tolerance;
 }
 
-export default { checkSlippage };
+export function calcMinOut(amount: bigint, slippageBps: number): bigint {
+  const factor = BPS_PER_UNIT - BigInt(slippageBps);
+  return (amount * factor) / BPS_PER_UNIT;
+}
+
+export function computeSlippageAdjustedOut(
+  amount: bigint,
+  slippageBps: number
+): bigint {
+  return calcMinOut(amount, slippageBps);
+}
+
+export default {
+  checkSlippage,
+  calcMinOut,
+  computeSlippageAdjustedOut,
+  DEFAULT_SLIPPAGE_BPS,
+  DEFAULT_SLIPPAGE
+};


### PR DESCRIPTION
## Summary
- add basis-point utilities for slippage: `calcMinOut` and `computeSlippageAdjustedOut`
- expose default slippage constants and risk helpers

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689669462d98832a976f4e730fc2c2b1