### PR TITLE
Add guard checks for transaction safety

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -24,4 +24,5 @@ export {
   DEFAULT_SLIPPAGE_BPS,
   DEFAULT_SLIPPAGE
 } from './src/risk/slippage';
+export { checkGuards } from './src/risk/guards';
 export default main;

--- a/src/risk/guards.test.ts
+++ b/src/risk/guards.test.ts
@@ -1,0 +1,60 @@
+import { checkGuards } from './guards';
+
+test('checkGuards returns messages when all checks pass', () => {
+  const msgs = checkGuards({
+    gasPrice: 100n,
+    maxGasPrice: 200n,
+    reserve0: 1000n,
+    reserve1: 1500n,
+    minLiquidity: 500n,
+    blockTag: 10,
+    currentBlock: 12,
+    maxBlockTagDrift: 5
+  });
+  expect(msgs).toHaveLength(3);
+});
+
+test('checkGuards throws on high gas price', () => {
+  expect(() =>
+    checkGuards({
+      gasPrice: 300n,
+      maxGasPrice: 200n,
+      reserve0: 1000n,
+      reserve1: 1500n,
+      minLiquidity: 500n,
+      blockTag: 10,
+      currentBlock: 12,
+      maxBlockTagDrift: 5
+    })
+  ).toThrow('Gas price');
+});
+
+test('checkGuards throws on low liquidity', () => {
+  expect(() =>
+    checkGuards({
+      gasPrice: 100n,
+      maxGasPrice: 200n,
+      reserve0: 300n,
+      reserve1: 400n,
+      minLiquidity: 500n,
+      blockTag: 10,
+      currentBlock: 12,
+      maxBlockTagDrift: 5
+    })
+  ).toThrow('Pool liquidity');
+});
+
+test('checkGuards throws on block tag drift', () => {
+  expect(() =>
+    checkGuards({
+      gasPrice: 100n,
+      maxGasPrice: 200n,
+      reserve0: 1000n,
+      reserve1: 1500n,
+      minLiquidity: 500n,
+      blockTag: 10,
+      currentBlock: 20,
+      maxBlockTagDrift: 5
+    })
+  ).toThrow('Block tag drift');
+});

--- a/src/risk/guards.ts
+++ b/src/risk/guards.ts
@@ -1,0 +1,54 @@
+export interface GuardContext {
+  /** Current gas price in wei */
+  gasPrice: bigint;
+  /** Maximum allowed gas price in wei */
+  maxGasPrice: bigint;
+  /** Reserve of token0 in the pool */
+  reserve0: bigint;
+  /** Reserve of token1 in the pool */
+  reserve1: bigint;
+  /** Minimum acceptable reserve for each token */
+  minLiquidity: bigint;
+  /** Block number the quote was produced at */
+  blockTag: number;
+  /** Latest block number from the provider */
+  currentBlock: number;
+  /** Maximum allowed difference between currentBlock and blockTag */
+  maxBlockTagDrift: number;
+}
+
+/**
+ * Checks a set of risk guards related to transaction execution.
+ *
+ * @param ctx - Context containing runtime information and limits
+ * @returns An array of messages for each successful check
+ * @throws Error if any guard condition is violated
+ */
+export function checkGuards(ctx: GuardContext): string[] {
+  const messages: string[] = [];
+
+  if (ctx.gasPrice > ctx.maxGasPrice) {
+    throw new Error(`Gas price ${ctx.gasPrice} exceeds max ${ctx.maxGasPrice}`);
+  }
+  messages.push('gas price within limit');
+
+  if (ctx.reserve0 < ctx.minLiquidity || ctx.reserve1 < ctx.minLiquidity) {
+    throw new Error(
+      `Pool liquidity below threshold ${ctx.minLiquidity}: ` +
+        `(${ctx.reserve0}, ${ctx.reserve1})`
+    );
+  }
+  messages.push('pool liquidity sufficient');
+
+  const drift = Math.abs(ctx.currentBlock - ctx.blockTag);
+  if (drift > ctx.maxBlockTagDrift) {
+    throw new Error(
+      `Block tag drift ${drift} exceeds max ${ctx.maxBlockTagDrift}`
+    );
+  }
+  messages.push('block tag drift within limit');
+
+  return messages;
+}
+
+export default { checkGuards };


### PR DESCRIPTION
## Summary
- add `checkGuards` to validate gas price, pool liquidity, and block tag drift
- expose guard validation via package index
- test guard success and failure cases

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68966b26beb4832aaf5f82348751c9d9