### PR TITLE
feat: add arbitrage CLI and simulation utilities

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env ts-node
+import { JsonRpcProvider } from 'ethers';
+import dotenv from 'dotenv';
+import { q98 } from './src/utils/fixed';
+import { buildCandidates, simulateCandidate } from './src/core/arbitrage';
+import type { VenueConfig } from './src/core/candidates';
+
+dotenv.config();
+
+function getArg(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  return process.argv.slice(2).find((a) => a.startsWith(prefix))?.slice(prefix.length);
+}
+
+function getEnv(name: string, fallback?: string): string | undefined {
+  return process.env[name] ?? fallback;
+}
+
+async function main() {
+  const rpc = getArg('rpc') ?? getEnv('RPC_URL') ?? 'http://localhost:8545';
+  const provider = new JsonRpcProvider(rpc);
+
+  const venuesJson = getArg('venues') ?? getEnv('VENUES') ?? '[]';
+  const venues: VenueConfig[] = JSON.parse(venuesJson);
+
+  const amountInStr = getArg('amount-in') ?? getEnv('AMOUNT_IN') ?? '0';
+  const amountIn = BigInt(amountInStr);
+
+  const token0Decimals = Number(getArg('token0-decimals') ?? getEnv('TOKEN0_DECIMALS') ?? '18');
+  const token0Price = BigInt(getArg('token0-price-usd') ?? getEnv('TOKEN0_PRICE_USD') ?? '0');
+  const token1Decimals = Number(getArg('token1-decimals') ?? getEnv('TOKEN1_DECIMALS') ?? '18');
+  const token1Price = BigInt(getArg('token1-price-usd') ?? getEnv('TOKEN1_PRICE_USD') ?? '0');
+
+  const slippageBps = Number(getArg('slippage-bps') ?? getEnv('SLIPPAGE_BPS') ?? '0');
+  const gasUnits = BigInt(getArg('gas-units') ?? getEnv('GAS_UNITS') ?? '0');
+  const ethUsd = Number(getArg('eth-usd') ?? getEnv('ETH_USD') ?? '0');
+  const minProfitUsd = Number(getArg('min-profit-usd') ?? getEnv('MIN_PROFIT_USD') ?? '0');
+
+  const token0 = { decimals: token0Decimals, priceUsd: q98(token0Price) };
+  const token1 = { decimals: token1Decimals, priceUsd: q98(token1Price) };
+
+  const candidates = await buildCandidates({
+    provider,
+    venues,
+    amountIn,
+    token0,
+    token1,
+    slippageBps,
+    gasUnits,
+    ethUsd,
+    minProfitUsd
+  });
+
+  console.log('candidates:', candidates);
+
+  for (const c of candidates) {
+    const sim = await simulateCandidate({
+      candidate: c,
+      provider,
+      venues,
+      amountIn,
+      token0,
+      token1,
+      slippageBps,
+      gasUnits,
+      ethUsd
+    });
+    console.log('simulation:', sim);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ export {
   submitV3Swap
 } from './src/core/v3';
 export { fetchCandidates } from './src/core/candidates';
+export { buildCandidates, simulateCandidate } from './src/core/arbitrage';
 export { buildStrategy } from './src/core/strategy';
 export {
   checkSlippage,

--- a/src/core/arbitrage.test.ts
+++ b/src/core/arbitrage.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { buildCandidates, simulateCandidate } from './arbitrage';
+import * as v2 from './v2';
+import * as v3 from './v3';
+import { q98 } from '../utils/fixed';
+
+const provider = {
+  getFeeData: async () => ({ gasPrice: 1n * 10n ** 9n })
+} as any;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('simulateCandidate recomputes profit', async () => {
+  vi.spyOn(v2, 'getV2Quote').mockResolvedValue({
+    token0: '',
+    token1: '',
+    reserve0: 0n,
+    reserve1: 0n,
+    price0: 100,
+    price1: 0
+  });
+  vi.spyOn(v3, 'getV3Quote').mockResolvedValue({
+    token0: '',
+    token1: '',
+    sqrtPriceX96: 0n,
+    tick: 0,
+    fee: 0,
+    price: 105
+  });
+
+  const venues = [
+    { name: 'A', type: 'v2' as const, address: '0x1' },
+    { name: 'B', type: 'v3' as const, address: '0x2' }
+  ];
+
+  const params = {
+    provider,
+    venues,
+    amountIn: 1n * 10n ** 18n,
+    token0: { decimals: 18, priceUsd: q98(2000) },
+    token1: { decimals: 6, priceUsd: q98(1) },
+    slippageBps: 0,
+    gasUnits: 100000n,
+    ethUsd: 2000,
+    minProfitUsd: 1
+  };
+
+  const candidates = await buildCandidates(params);
+  expect(candidates).toHaveLength(1);
+
+  const sim = await simulateCandidate({
+    candidate: candidates[0],
+    provider,
+    venues,
+    amountIn: params.amountIn,
+    token0: params.token0,
+    token1: params.token1,
+    slippageBps: params.slippageBps,
+    gasUnits: params.gasUnits,
+    ethUsd: params.ethUsd
+  });
+
+  expect(sim.profitUsd).toBeCloseTo(candidates[0].profitUsd, 2);
+});

--- a/src/core/arbitrage.ts
+++ b/src/core/arbitrage.ts
@@ -1,0 +1,79 @@
+import { type Provider } from 'ethers';
+import { fetchCandidates, type Candidate, type CandidateParams, type VenueConfig } from './candidates';
+import { getV2Quote } from './v2';
+import { getV3Quote } from './v3';
+import { fromQ96 } from '../utils/fixed';
+import { estimateGasUsd } from '../utils/gas';
+import type { TokenInfo } from '../utils/prices';
+
+/**
+ * Builds arbitrage candidates using the same logic as {@link fetchCandidates}.
+ * This function provides a semantic alias for CLI usage.
+ */
+export async function buildCandidates(params: CandidateParams): Promise<Candidate[]> {
+  return fetchCandidates(params);
+}
+
+export interface SimulateCandidateParams {
+  /** Candidate to simulate */
+  candidate: Candidate;
+  /** Provider for fetching fresh quotes */
+  provider: Provider;
+  /** Venue configurations so addresses/types can be resolved */
+  venues: VenueConfig[];
+  /** Amount of token0 to trade */
+  amountIn: bigint;
+  /** Token0 info */
+  token0: TokenInfo;
+  /** Token1 info */
+  token1: TokenInfo;
+  /** Slippage tolerance in bps */
+  slippageBps: number;
+  /** Gas units expected */
+  gasUnits: bigint;
+  /** Current ETH price in USD */
+  ethUsd: number;
+}
+
+/**
+ * Recomputes the expected profit for a candidate using fresh pool quotes.
+ * This provides a lightweight simulation used by the CLI to verify results.
+ */
+export async function simulateCandidate({
+  candidate,
+  provider,
+  venues,
+  amountIn,
+  token0,
+  token1,
+  slippageBps,
+  gasUnits,
+  ethUsd
+}: SimulateCandidateParams): Promise<{ buy: string; sell: string; profitUsd: number }> {
+  const buyConfig = venues.find((v) => v.name === candidate.buy);
+  const sellConfig = venues.find((v) => v.name === candidate.sell);
+  if (!buyConfig || !sellConfig) {
+    throw new Error('Candidate venues not found in configuration');
+  }
+
+  const [buyQuote, sellQuote] = await Promise.all([
+    buyConfig.type === 'v2' ? getV2Quote(provider, buyConfig.address) : getV3Quote(provider, buyConfig.address),
+    sellConfig.type === 'v2' ? getV2Quote(provider, sellConfig.address) : getV3Quote(provider, sellConfig.address)
+  ]);
+
+  const buyPrice = 'price0' in buyQuote ? buyQuote.price0 : buyQuote.price;
+  const sellPrice = 'price0' in sellQuote ? sellQuote.price0 : sellQuote.price;
+  const slip = slippageBps / 10_000;
+  const amount0 = Number(amountIn) / 10 ** token0.decimals;
+  const token1Usd = fromQ96(token1.priceUsd);
+  const gasUsd = await estimateGasUsd({ provider, gasUnits, ethUsd });
+
+  const buyAdj = buyPrice * (1 + slip);
+  const sellAdj = sellPrice * (1 - slip);
+  const profitToken1 = (sellAdj - buyAdj) * amount0;
+  const profitUsd = profitToken1 * token1Usd - gasUsd;
+
+  return { buy: candidate.buy, sell: candidate.sell, profitUsd };
+}
+
+export default { buildCandidates, simulateCandidate };


### PR DESCRIPTION
## Summary
- add `buildCandidates` and `simulateCandidate` helpers for computing and verifying arbitrage profit
- create CLI that accepts token and pool config via args/env and runs candidate build then simulation
- expose new helpers from library exports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896710a3b80832a88a76a8fbdc1c426