### PR TITLE
feat: add generic swap simulation

### DIFF
--- a/src/core/sim.test.ts
+++ b/src/core/sim.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from 'vitest';
+import { simulateSwap, simulateRoute } from './sim';
+import type { V2SwapParams } from './v2';
+import type { V3SwapParams } from './v3';
+
+test('simulateSwap handles zero liquidity', () => {
+  const params: V2SwapParams = {
+    quote: {
+      token0: 'A',
+      token1: 'B',
+      reserve0: 0n,
+      reserve1: 1n,
+      price0: 1,
+      price1: 1
+    },
+    amountIn: 100n,
+    slippageBps: 100,
+    feeBps: 30
+  };
+  const res = simulateSwap(params);
+  expect(res.ok).toBe(false);
+  expect(res.expectedProfit).toBe(0);
+});
+
+test('simulateSwap marks negative profit as not ok', () => {
+  const params: V2SwapParams = {
+    quote: {
+      token0: 'A',
+      token1: 'B',
+      reserve0: 1000n,
+      reserve1: 1000n,
+      price0: 2,
+      price1: 0.5
+    },
+    amountIn: 100n,
+    slippageBps: 10000,
+    feeBps: 30
+  };
+  const res = simulateSwap(params);
+  expect(res.ok).toBe(false);
+  expect(res.expectedProfit).toBeLessThan(0);
+});
+
+test('simulateRoute aggregates swap results', () => {
+  const swap1: V2SwapParams = {
+    quote: {
+      token0: 'A',
+      token1: 'B',
+      reserve0: 1000n,
+      reserve1: 1000n,
+      price0: 2,
+      price1: 0.5
+    },
+    amountIn: 100n,
+    slippageBps: 10000,
+    feeBps: 30
+  };
+  const swap2: V3SwapParams = {
+    quote: {
+      token0: 'B',
+      token1: 'C',
+      sqrtPriceX96: 1n,
+      tick: 0,
+      fee: 0,
+      price: 0.5
+    },
+    amountIn: 100n,
+    slippageBps: 10000
+  };
+
+  const r1 = simulateSwap(swap1);
+  const r2 = simulateSwap(swap2);
+  const route = simulateRoute([swap1, swap2]);
+  expect(route.expectedProfit).toBeCloseTo(r1.expectedProfit + r2.expectedProfit, 6);
+  expect(route.ok).toBe(false);
+});

--- a/src/core/sim.ts
+++ b/src/core/sim.ts
@@ -7,3 +7,69 @@ export interface SimResult {
   /** Expected profit in output token terms */
   expectedProfit: number;
 }
+
+import type { V2SwapParams } from './v2';
+import { simulateV2Swap } from './v2';
+import type { V3SwapParams } from './v3';
+import { simulateV3Swap } from './v3';
+
+export type SwapParams = V2SwapParams | V3SwapParams;
+
+function isV2(params: SwapParams): params is V2SwapParams {
+  // V2 quotes contain reserve information
+  return 'reserve0' in (params as any).quote;
+}
+
+function isV3(params: SwapParams): params is V3SwapParams {
+  // V3 quotes include the sqrtPriceX96 field
+  return 'sqrtPriceX96' in (params as any).quote;
+}
+
+/**
+ * Simulates a swap on either a V2 or V3 pool and performs basic
+ * sanity checks such as liquidity and profit validation.
+ */
+export function simulateSwap(params: SwapParams): SimResult {
+  if (isV2(params)) {
+    const { quote } = params;
+    if (quote.reserve0 === 0n || quote.reserve1 === 0n) {
+      return { ok: false, expectedProfit: 0 };
+    }
+    const res = simulateV2Swap(params);
+    if (!res.ok || res.expectedProfit <= 0) {
+      return { ...res, ok: false };
+    }
+    return res;
+  }
+
+  if (isV3(params)) {
+    const { quote } = params;
+    if (quote.sqrtPriceX96 === 0n) {
+      return { ok: false, expectedProfit: 0 };
+    }
+    const res = simulateV3Swap(params);
+    if (!res.ok || res.expectedProfit <= 0) {
+      return { ...res, ok: false };
+    }
+    return res;
+  }
+
+  return { ok: false, expectedProfit: 0 };
+}
+
+/**
+ * Runs simulation over an array of swaps. The route is considered OK
+ * only if all individual swaps succeed and yield positive profit.
+ */
+export function simulateRoute(swaps: SwapParams[]): SimResult {
+  let ok = true;
+  let expectedProfit = 0;
+  for (const swap of swaps) {
+    const res = simulateSwap(swap);
+    ok &&= res.ok;
+    expectedProfit += res.expectedProfit;
+  }
+  return { ok, expectedProfit };
+}
+
+export default { simulateSwap, simulateRoute };


### PR DESCRIPTION
## Summary
- add unified `simulateSwap` and `simulateRoute` helpers for V2/V3 pools
- handle zero-liquidity and negative-profit scenarios
- cover swap simulation edge cases with new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68969444f208832a88f85050e75f2fec