### PR TITLE
feat: add ui components with tailwind styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,10 @@
         "@types/node": "^24.2.0",
         "@typescript-eslint/eslint-plugin": "^8.39.0",
         "@typescript-eslint/parser": "^8.39.0",
+        "autoprefixer": "^10.4.21",
         "eslint": "^9.32.0",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^4.1.11",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
@@ -16480,6 +16483,18 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/react-scripts/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/react-scripts/node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -16523,6 +16538,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react-scripts/node_modules/tailwindcss": {
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.6",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/read-cache": {
@@ -18494,53 +18546,11 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.6.0",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.3.2",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.21.6",
-        "lilconfig": "^3.1.3",
-        "micromatch": "^4.0.8",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2",
-        "postcss-nested": "^6.2.0",
-        "postcss-selector-parser": "^6.1.2",
-        "resolve": "^1.22.8",
-        "sucrase": "^3.35.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
+      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,10 @@
     "@types/node": "^24.2.0",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.39.0",
+    "autoprefixer": "^10.4.21",
     "eslint": "^9.32.0",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.11",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import './App.css';
-import { BrowserRouter, Routes, Route, Link, Outlet } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Outlet } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './api/queryClient';
 import { AppStoreProvider } from './store/useAppStore';
@@ -10,41 +10,18 @@ import Simulator from './pages/Simulator';
 import Strategies from './pages/Strategies';
 import Settings from './pages/Settings';
 import Logs from './pages/Logs';
+import Header from './components/Header';
+import SidebarNav from './components/SidebarNav';
 
 function Layout() {
   return (
-    <div className="layout">
-      <Sidebar />
-      <div className="main">
+    <div className="flex">
+      <SidebarNav />
+      <div className="flex-1">
         <Header />
         <Outlet />
       </div>
     </div>
-  );
-}
-
-function Sidebar() {
-  return (
-    <aside className="sidebar">
-      <nav>
-        <ul>
-          <li><Link to="/">Dashboard</Link></li>
-          <li><Link to="/pools">Pools</Link></li>
-          <li><Link to="/simulator">Simulator</Link></li>
-          <li><Link to="/strategies">Strategies</Link></li>
-          <li><Link to="/settings">Settings</Link></li>
-          <li><Link to="/logs">Logs</Link></li>
-        </ul>
-      </nav>
-    </aside>
-  );
-}
-
-function Header() {
-  return (
-    <header className="header">
-      <h1>Arbitrage Engine</h1>
-    </header>
   );
 }
 

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -1,0 +1,15 @@
+interface AmountInputProps {
+  value: number;
+  onChange: (v: number) => void;
+}
+
+export default function AmountInput({ value, onChange }: AmountInputProps) {
+  return (
+    <input
+      type="number"
+      className="border p-2 rounded w-full"
+      value={value}
+      onChange={(e) => onChange(Number(e.target.value))}
+    />
+  );
+}

--- a/src/components/CandidateTable.tsx
+++ b/src/components/CandidateTable.tsx
@@ -1,0 +1,35 @@
+export interface Candidate {
+  id: string;
+  profitUsd: number;
+  [key: string]: any;
+}
+
+interface CandidateTableProps {
+  candidates: Candidate[];
+  onSelect: (c: Candidate) => void;
+}
+
+export default function CandidateTable({ candidates, onSelect }: CandidateTableProps) {
+  return (
+    <table className="min-w-full text-left border">
+      <thead className="bg-gray-100">
+        <tr>
+          <th className="p-2">ID</th>
+          <th className="p-2">Profit (USD)</th>
+        </tr>
+      </thead>
+      <tbody>
+        {candidates.map((c) => (
+          <tr
+            key={c.id}
+            className="hover:bg-gray-50 cursor-pointer"
+            onClick={() => onSelect(c)}
+          >
+            <td className="p-2">{c.id}</td>
+            <td className="p-2">{c.profitUsd}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/ExecutionToggle.tsx
+++ b/src/components/ExecutionToggle.tsx
@@ -1,0 +1,29 @@
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export default function ExecutionToggle() {
+  const [enabled, setEnabled] = useState(false);
+  const exec = useMutation({
+    mutationFn: async (next: boolean) => {
+      const res = await fetch('/api/execute', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: next }),
+      });
+      return res.json();
+    },
+  });
+
+  return (
+    <button
+      onClick={() => {
+        const next = !enabled;
+        setEnabled(next);
+        exec.mutate(next);
+      }}
+      className="bg-blue-500 text-white px-4 py-2 rounded"
+    >
+      {enabled ? 'Stop' : 'Start'}
+    </button>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,15 @@
+import ExecutionToggle from './ExecutionToggle';
+import { useAppStore } from '../store/useAppStore';
+
+export default function Header() {
+  const toggleSidebar = useAppStore((s) => s.toggleSidebar);
+  return (
+    <header className="bg-gray-800 text-white p-4 flex items-center justify-between">
+      <button className="mr-4" onClick={toggleSidebar} aria-label="Toggle sidebar">
+        ☰
+      </button>
+      <h1 className="text-xl font-bold flex-1">Arbitrage Engine</h1>
+      <ExecutionToggle />
+    </header>
+  );
+}

--- a/src/components/LogStream.tsx
+++ b/src/components/LogStream.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+export default function LogStream() {
+  const [logs, setLogs] = useState<string[]>([]);
+
+  useEffect(() => {
+    const es = new EventSource('/api/stream');
+    es.onmessage = (e) => {
+      setLogs((l) => [...l, e.data]);
+    };
+    return () => es.close();
+  }, []);
+
+  return (
+    <div className="bg-black text-green-400 p-4 font-mono h-96 overflow-y-auto">
+      {logs.map((l, i) => (
+        <div key={i}>{l}</div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/PoolQuoteCard.tsx
+++ b/src/components/PoolQuoteCard.tsx
@@ -1,0 +1,13 @@
+interface PoolQuote {
+  pool: string;
+  price: number;
+}
+
+export default function PoolQuoteCard({ quote }: { quote: PoolQuote }) {
+  return (
+    <div className="bg-white rounded shadow p-4">
+      <div className="text-sm text-gray-500">{quote.pool}</div>
+      <div className="text-2xl font-bold">{quote.price}</div>
+    </div>
+  );
+}

--- a/src/components/SettingsForm.tsx
+++ b/src/components/SettingsForm.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import TokenSelect from './TokenSelect';
+import VenueSelect from './VenueSelect';
+import AmountInput from './AmountInput';
+
+export default function SettingsForm() {
+  const [token0, setToken0] = useState('ETH');
+  const [token1, setToken1] = useState('DAI');
+  const [venue, setVenue] = useState('uniswap');
+  const [amount, setAmount] = useState(0);
+
+  const save = useMutation({
+    mutationFn: async () => {
+      const res = await fetch('/api/candidates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token0, token1, venue, amount }),
+      });
+      return res.json();
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        save.mutate();
+      }}
+      className="space-y-4"
+    >
+      <div>
+        <label className="block text-sm mb-1">Token 0</label>
+        <TokenSelect value={token0} onChange={setToken0} />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Token 1</label>
+        <TokenSelect value={token1} onChange={setToken1} />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Venue</label>
+        <VenueSelect value={venue} onChange={setVenue} />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Amount</label>
+        <AmountInput value={amount} onChange={setAmount} />
+      </div>
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
+        Save
+      </button>
+      {save.data && <div className="text-sm text-gray-500">Saved</div>}
+    </form>
+  );
+}

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -1,0 +1,35 @@
+import { NavLink } from 'react-router-dom';
+import { useAppStore } from '../store/useAppStore';
+
+const links = [
+  { to: '/', label: 'Dashboard', end: true },
+  { to: '/pools', label: 'Pools' },
+  { to: '/simulator', label: 'Simulator' },
+  { to: '/strategies', label: 'Strategies' },
+  { to: '/settings', label: 'Settings' },
+  { to: '/logs', label: 'Logs' },
+];
+
+export default function SidebarNav() {
+  const open = useAppStore((s) => s.sidebarOpen);
+  return (
+    <aside
+      className={`${open ? 'block' : 'hidden'} bg-gray-900 text-white w-64 min-h-screen`}
+    >
+      <nav className="p-4 space-y-2">
+        {links.map((l) => (
+          <NavLink
+            key={l.to}
+            to={l.to}
+            end={l.end}
+            className={({ isActive }) =>
+              `block p-2 rounded hover:bg-gray-700 ${isActive ? 'bg-gray-700' : ''}`
+            }
+          >
+            {l.label}
+          </NavLink>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/src/components/SimulatorPanel.tsx
+++ b/src/components/SimulatorPanel.tsx
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+import type { Candidate } from './CandidateTable';
+
+export default function SimulatorPanel({ candidate }: { candidate: Candidate }) {
+  const simulate = useMutation({
+    mutationFn: async () => {
+      const res = await fetch('/api/simulate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ candidate, params: {} }),
+      });
+      return res.json();
+    },
+  });
+
+  return (
+    <div className="space-y-2">
+      <button
+        onClick={() => simulate.mutate()}
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        Simulate
+      </button>
+      {simulate.data && (
+        <pre className="bg-gray-100 p-2 rounded overflow-auto">
+          {JSON.stringify(simulate.data, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -1,0 +1,13 @@
+interface StatCardProps {
+  title: string;
+  value: string | number;
+}
+
+export default function StatCard({ title, value }: StatCardProps) {
+  return (
+    <div className="bg-white rounded shadow p-4">
+      <div className="text-sm text-gray-500">{title}</div>
+      <div className="text-2xl font-bold">{value}</div>
+    </div>
+  );
+}

--- a/src/components/StrategyEditor.tsx
+++ b/src/components/StrategyEditor.tsx
@@ -1,0 +1,40 @@
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export default function StrategyEditor() {
+  const [text, setText] = useState('');
+  const save = useMutation({
+    mutationFn: async () => {
+      const res = await fetch('/api/execute', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ strategy: text }),
+      });
+      return res.json();
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        save.mutate();
+      }}
+      className="space-y-2"
+    >
+      <textarea
+        className="w-full border p-2 rounded"
+        rows={6}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <button
+        type="submit"
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        Save
+      </button>
+      {save.data && <div className="text-sm text-gray-500">Saved</div>}
+    </form>
+  );
+}

--- a/src/components/TokenSelect.tsx
+++ b/src/components/TokenSelect.tsx
@@ -1,0 +1,18 @@
+interface TokenSelectProps {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+export default function TokenSelect({ value, onChange }: TokenSelectProps) {
+  return (
+    <select
+      className="border p-2 rounded w-full"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="ETH">ETH</option>
+      <option value="DAI">DAI</option>
+      <option value="USDC">USDC</option>
+    </select>
+  );
+}

--- a/src/components/VenueSelect.tsx
+++ b/src/components/VenueSelect.tsx
@@ -1,0 +1,17 @@
+interface VenueSelectProps {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+export default function VenueSelect({ value, onChange }: VenueSelectProps) {
+  return (
+    <select
+      className="border p-2 rounded w-full"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="uniswap">Uniswap</option>
+      <option value="sushiswap">Sushiswap</option>
+    </select>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import StatCard from '../components/StatCard';
+
 export default function Dashboard() {
-  return <div>Dashboard</div>;
+  const { data } = useQuery({
+    queryKey: ['candidates'],
+    queryFn: async () => {
+      const res = await fetch('/api/candidates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      return res.json();
+    },
+  });
+
+  const count = data?.candidates?.length ?? 0;
+
+  return (
+    <div className="p-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+      <StatCard title="Candidates" value={count} />
+    </div>
+  );
 }

--- a/src/pages/Logs.tsx
+++ b/src/pages/Logs.tsx
@@ -1,3 +1,9 @@
+import LogStream from '../components/LogStream';
+
 export default function Logs() {
-  return <div>Logs</div>;
+  return (
+    <div className="p-4">
+      <LogStream />
+    </div>
+  );
 }

--- a/src/pages/Pools.tsx
+++ b/src/pages/Pools.tsx
@@ -1,3 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import PoolQuoteCard from '../components/PoolQuoteCard';
+
 export default function Pools() {
-  return <div>Pools</div>;
+  const { data } = useQuery({
+    queryKey: ['pools'],
+    queryFn: async () => {
+      const res = await fetch('/api/candidates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      return res.json();
+    },
+  });
+
+  const quotes = data?.candidates ?? [];
+
+  return (
+    <div className="p-4 grid gap-4 md:grid-cols-2">
+      {quotes.map((q: any) => (
+        <PoolQuoteCard key={q.id} quote={{ pool: q.id, price: q.profitUsd }} />
+      ))}
+    </div>
+  );
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,3 +1,9 @@
+import SettingsForm from '../components/SettingsForm';
+
 export default function Settings() {
-  return <div>Settings</div>;
+  return (
+    <div className="p-4 max-w-md">
+      <SettingsForm />
+    </div>
+  );
 }

--- a/src/pages/Simulator.tsx
+++ b/src/pages/Simulator.tsx
@@ -1,3 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import CandidateTable, { Candidate } from '../components/CandidateTable';
+import SimulatorPanel from '../components/SimulatorPanel';
+
 export default function Simulator() {
-  return <div>Simulator</div>;
+  const { data } = useQuery({
+    queryKey: ['candidates'],
+    queryFn: async () => {
+      const res = await fetch('/api/candidates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      return res.json();
+    },
+  });
+
+  const [selected, setSelected] = useState<Candidate | null>(null);
+  const candidates = data?.candidates ?? [];
+
+  return (
+    <div className="p-4 grid gap-4 md:grid-cols-2">
+      <CandidateTable candidates={candidates} onSelect={setSelected} />
+      {selected && <SimulatorPanel candidate={selected} />}
+    </div>
+  );
 }

--- a/src/pages/Strategies.tsx
+++ b/src/pages/Strategies.tsx
@@ -1,3 +1,9 @@
+import StrategyEditor from '../components/StrategyEditor';
+
 export default function Strategies() {
-  return <div>Strategies</div>;
+  return (
+    <div className="p-4">
+      <StrategyEditor />
+    </div>
+  );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind CSS and PostCSS
- implement reusable components (Header, SidebarNav, tables, forms, etc.)
- wire pages to components and React Query endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68969bc74d98832ab0d855e81915752e