### PR TITLE
feat: add execution toggle and safety thresholds

### DIFF
--- a/src/components/ExecutionToggle.tsx
+++ b/src/components/ExecutionToggle.tsx
@@ -1,8 +1,12 @@
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useExecutionStore } from '../store/useExecutionStore';
 
 export default function ExecutionToggle() {
-  const [enabled, setEnabled] = useState(false);
+  const enabled = useExecutionStore((s) => s.enabled);
+  const setEnabled = useExecutionStore((s) => s.setEnabled);
+  const [confirm, setConfirm] = useState('');
+
   const exec = useMutation({
     mutationFn: async (next: boolean) => {
       const res = await fetch('/api/execute', {
@@ -14,16 +18,40 @@ export default function ExecutionToggle() {
     },
   });
 
+  if (enabled) {
+    return (
+      <button
+        onClick={() => {
+          setEnabled(false);
+          exec.mutate(false);
+        }}
+        className="bg-red-500 text-white px-4 py-2 rounded"
+      >
+        Disable Execution
+      </button>
+    );
+  }
+
   return (
-    <button
-      onClick={() => {
-        const next = !enabled;
-        setEnabled(next);
-        exec.mutate(next);
-      }}
-      className="bg-blue-500 text-white px-4 py-2 rounded"
-    >
-      {enabled ? 'Stop' : 'Start'}
-    </button>
+    <div className="flex items-center space-x-2">
+      <input
+        type="text"
+        value={confirm}
+        onChange={(e) => setConfirm(e.target.value)}
+        placeholder="Type ENABLE"
+        className="border p-1 rounded text-black"
+      />
+      <button
+        onClick={() => {
+          setEnabled(true);
+          exec.mutate(true);
+          setConfirm('');
+        }}
+        disabled={confirm !== 'ENABLE'}
+        className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50"
+      >
+        Enable Execution
+      </button>
+    </div>
   );
 }

--- a/src/components/SimulatorPanel.tsx
+++ b/src/components/SimulatorPanel.tsx
@@ -1,7 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
 import type { Candidate } from './CandidateTable';
+import { useExecutionStore } from '../store/useExecutionStore';
 
 export default function SimulatorPanel({ candidate }: { candidate: Candidate }) {
+  const { slippageBps, gasCeiling, minProfitUsd, enabled } = useExecutionStore();
   const simulate = useMutation({
     mutationFn: async () => {
       const res = await fetch('/api/simulate', {
@@ -13,13 +15,43 @@ export default function SimulatorPanel({ candidate }: { candidate: Candidate }) 
     },
   });
 
+  const execute = useMutation({
+    mutationFn: async () => {
+      const res = await fetch('/api/execute', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ candidate, params: {} }),
+      });
+      return res.json();
+    },
+  });
+
+  const warnings: string[] = [];
+  if (candidate.profitUsd < minProfitUsd) {
+    warnings.push('Profit below minimum threshold');
+  }
+
   return (
     <div className="space-y-2">
+      <div className="text-sm text-gray-700">
+        Slippage: {slippageBps} bps | Gas ceiling: {gasCeiling} | Min profit: $
+        {minProfitUsd}
+      </div>
+      {warnings.length > 0 && (
+        <div className="text-yellow-700 text-sm">{warnings.join(', ')}</div>
+      )}
       <button
         onClick={() => simulate.mutate()}
         className="bg-blue-500 text-white px-4 py-2 rounded"
       >
         Simulate
+      </button>
+      <button
+        onClick={() => execute.mutate()}
+        disabled={!enabled || warnings.length > 0}
+        className="bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50"
+      >
+        Execute
       </button>
       {simulate.data && (
         <pre className="bg-gray-100 p-2 rounded overflow-auto">

--- a/src/components/StrategyEditor.tsx
+++ b/src/components/StrategyEditor.tsx
@@ -1,8 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useExecutionStore } from '../store/useExecutionStore';
 
 export default function StrategyEditor() {
   const [text, setText] = useState('');
+  const enabled = useExecutionStore((s) => s.enabled);
   const save = useMutation({
     mutationFn: async () => {
       const res = await fetch('/api/execute', {
@@ -30,7 +32,8 @@ export default function StrategyEditor() {
       />
       <button
         type="submit"
-        className="bg-blue-500 text-white px-4 py-2 rounded"
+        disabled={!enabled}
+        className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50"
       >
         Save
       </button>

--- a/src/store/useExecutionStore.ts
+++ b/src/store/useExecutionStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+interface ExecutionState {
+  /** Whether execution is currently enabled */
+  enabled: boolean;
+  /** Slippage tolerance in basis points */
+  slippageBps: number;
+  /** Maximum allowed gas price (gas ceiling) */
+  gasCeiling: number;
+  /** Minimum profit threshold in USD */
+  minProfitUsd: number;
+  /** Enable or disable execution */
+  setEnabled: (enabled: boolean) => void;
+  /** Update execution parameters */
+  setParams: (params: Partial<Pick<ExecutionState, 'slippageBps' | 'gasCeiling' | 'minProfitUsd'>>) => void;
+}
+
+export const useExecutionStore = create<ExecutionState>((set) => ({
+  enabled: false,
+  slippageBps: Number(process.env.REACT_APP_SLIPPAGE_BPS ?? 0),
+  gasCeiling: Number(process.env.REACT_APP_GAS_CEILING ?? 0),
+  minProfitUsd: Number(process.env.REACT_APP_MIN_PROFIT_USD ?? 0),
+  setEnabled: (enabled) => set({ enabled }),
+  setParams: (params) => set(params),
+}));
+
+export default useExecutionStore;


### PR DESCRIPTION
## Summary
- display slippage tolerance, gas ceiling and minimum profit in simulator panel
- require typed confirmation to enable execution and share state via store
- disable execute actions when toggle is off and warn on threshold violations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68969d7cc4b8832a909173f86f429690