### PR TITLE
chore: add env templates and docker setup

### DIFF
--- a/.env.client
+++ b/.env.client
@@ -1,0 +1,6 @@
+# Client environment variables
+# Only non-secret vars prefixed with REACT_APP_ are exposed to the browser
+REACT_APP_API_URL=http://localhost:3001
+REACT_APP_SLIPPAGE_BPS=50
+REACT_APP_GAS_CEILING=300000
+REACT_APP_MIN_PROFIT_USD=10

--- a/.env.server
+++ b/.env.server
@@ -1,0 +1,5 @@
+# Server environment variables
+# copy to a local .env file and adjust for production secrets
+PORT=3001
+RPC_URL=http://localhost:8545
+AUTH_TOKEN=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,11 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# environment files
+.env*
+!.env.server
+!.env.client
+
+# build artifacts
+/dist

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,0 +1,19 @@
+# Build React frontend and serve with nginx
+FROM node:18-alpine AS build
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY public ./public
+COPY src ./src
+COPY tsconfig.json ./
+COPY tailwind.config.js postcss.config.js ./
+# Include client env variables for build
+COPY .env.client ./.env
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,14 @@
+# Simple Node API image
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install --omit=dev
+
+COPY tsconfig.json ./
+COPY server ./server
+COPY src ./src
+
+EXPOSE 3001
+CMD ["npm", "run", "server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    env_file: .env.server
+    ports:
+      - "3001:3001"
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.client
+    env_file: .env.client
+    ports:
+      - "3000:80"
+    depends_on:
+      - api
+
+  prometheus:
+    image: prom/prometheus
+    profiles: ["monitoring"]
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - api
+
+  grafana:
+    image: grafana/grafana
+    profiles: ["monitoring"]
+    ports:
+      - "3002:3000"
+    depends_on:
+      - prometheus

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'api'
+    static_configs:
+      - targets: ['api:3001']


### PR DESCRIPTION
## Summary
- add server and client env templates
- dockerize API and React app with compose and monitoring stack
- ignore env files and build output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68969f425cf8832abfcff6a9232bff9e