### PR TITLE
feat(validation): centralize candidate schemas

### DIFF
--- a/server/schemas.ts
+++ b/server/schemas.ts
@@ -1,15 +1,9 @@
 import { z } from 'zod';
-
-export const venueSchema = z.object({
-  name: z.string(),
-  type: z.enum(['v2', 'v3']),
-  address: z.string(),
-});
-
-export const tokenInfoSchema = z.object({
-  decimals: z.number(),
-  priceUsd: z.string(),
-});
+import {
+  CandidatesInput,
+  SimulateInput,
+  TCandidatesInput,
+} from '../src/shared/validation';
 
 export const candidateSchema = z.object({
   buy: z.string(),
@@ -17,36 +11,19 @@ export const candidateSchema = z.object({
   profitUsd: z.number(),
 });
 
-export const candidateParamsSchema = z.object({
-  providerUrl: z.string().url(),
-  venues: z.array(venueSchema),
-  amountIn: z.string(),
-  token0: tokenInfoSchema,
-  token1: tokenInfoSchema,
-  slippageBps: z.number(),
-  gasUnits: z.string(),
-  ethUsd: z.number(),
-  minProfitUsd: z.number().optional().default(0),
-});
-
-export const candidatesRequestSchema = candidateParamsSchema;
+export const candidatesRequestSchema = CandidatesInput;
 export const candidatesResponseSchema = z.object({
   candidates: z.array(candidateSchema),
 });
 
-export const simulateRequestSchema = z.object({
-  candidate: candidateSchema,
-  params: candidateParamsSchema,
-});
+export const simulateRequestSchema = SimulateInput;
 export const simulateResponseSchema = candidateSchema;
 
-export const executeRequestSchema = candidateParamsSchema;
+export const executeRequestSchema = CandidatesInput;
 export const executeResponseSchema = z.object({ ok: z.boolean() });
 
-export type VenueInput = z.infer<typeof venueSchema>;
-export type TokenInfoInput = z.infer<typeof tokenInfoSchema>;
 export type CandidateInput = z.infer<typeof candidateSchema>;
-export type CandidateParamsInput = z.infer<typeof candidateParamsSchema>;
+export type CandidateParamsInput = TCandidatesInput;
 export type CandidatesRequest = z.infer<typeof candidatesRequestSchema>;
 export type CandidatesResponse = z.infer<typeof candidatesResponseSchema>;
 export type SimulateRequest = z.infer<typeof simulateRequestSchema>;

--- a/src/shared/validation/index.ts
+++ b/src/shared/validation/index.ts
@@ -1,0 +1,1 @@
+export * from './schemas';

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+export const Address = z.string().regex(/^0x[a-fA-F0-9]{40}$/);
+
+export const BigintString = z.string().regex(/^\d+$/);
+
+export const TokenSchema = z.object({
+  decimals: z.number(),
+  priceUsd: BigintString,
+});
+
+export const VenueSchema = z.object({
+  name: z.string(),
+  type: z.enum(['v2', 'v3']),
+  address: Address,
+});
+
+export const CandidatesInput = z.object({
+  providerUrl: z.string().url(),
+  venues: z.array(VenueSchema),
+  amountIn: BigintString,
+  token0: TokenSchema,
+  token1: TokenSchema,
+  slippageBps: z.number(),
+  gasUnits: BigintString,
+  ethUsd: z.number(),
+  minProfitUsd: z.number().optional().default(0),
+});
+
+export const SimulateInput = z.object({
+  candidate: z.object({
+    buy: BigintString,
+    sell: BigintString,
+    profitUsd: z.number(),
+  }),
+  params: CandidatesInput,
+});
+
+export type TCandidatesInput = z.infer<typeof CandidatesInput>;
+export type TSimulateInput = z.infer<typeof SimulateInput>;
+


### PR DESCRIPTION
## Summary
- add reusable validation schemas for addresses, tokens, venues, candidate and simulation inputs
- re-export validation utilities via barrel file
- refactor server schemas to consume shared definitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896b9329128832a95729b11fe257b24