### PR TITLE
refactor: add API helpers

### DIFF
--- a/src/components/SettingsForm.tsx
+++ b/src/components/SettingsForm.tsx
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import TokenSelect from './TokenSelect';
 import VenueSelect from './VenueSelect';
 import AmountInput from './AmountInput';
+import { fetchCandidates } from '../lib/api';
 
 export default function SettingsForm() {
   const [token0, setToken0] = useState('ETH');
@@ -11,14 +12,8 @@ export default function SettingsForm() {
   const [amount, setAmount] = useState(0);
 
   const save = useMutation({
-    mutationFn: async () => {
-      const res = await fetch('/api/candidates', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token0, token1, venue, amount }),
-      });
-      return res.json();
-    },
+    mutationFn: () =>
+      fetchCandidates({ token0, token1, venue, amount } as any),
   });
 
   return (

--- a/src/components/SimulatorPanel.tsx
+++ b/src/components/SimulatorPanel.tsx
@@ -2,20 +2,14 @@ import { useMutation } from '@tanstack/react-query';
 import type { Candidate } from './CandidateTable';
 import { useSelector } from 'react-redux';
 import type { RootState } from '../store';
+import { simulate as simulateApi } from '../lib/api';
 
 export default function SimulatorPanel({ candidate }: { candidate: Candidate }) {
   const { slippageBps, gasCeiling, minProfitUsd, enabled } = useSelector(
     (state: RootState) => state.execution
   );
   const simulate = useMutation({
-    mutationFn: async () => {
-      const res = await fetch('/api/simulate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ candidate, params: {} }),
-      });
-      return res.json();
-    },
+    mutationFn: () => simulateApi({ candidate, params: {} } as any),
   });
 
   const execute = useMutation({

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,27 @@
+import { TCandidatesInput, TSimulateInput } from '../shared/validation';
+
+export async function fetchCandidates(input: TCandidatesInput) {
+  const res = await fetch('/api/candidates', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error);
+  }
+  return data;
+}
+
+export async function simulate(input: TSimulateInput) {
+  const res = await fetch('/api/simulate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error);
+  }
+  return data;
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,17 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import StatCard from '../components/StatCard';
+import { fetchCandidates } from '../lib/api';
 
 export default function Dashboard() {
   const { data } = useQuery({
     queryKey: ['candidates'],
-    queryFn: async () => {
-      const res = await fetch('/api/candidates', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      });
-      return res.json();
-    },
+    queryFn: () => fetchCandidates({} as any),
   });
 
   const count = data?.candidates?.length ?? 0;

--- a/src/pages/Pools.tsx
+++ b/src/pages/Pools.tsx
@@ -1,17 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import PoolQuoteCard from '../components/PoolQuoteCard';
+import { fetchCandidates } from '../lib/api';
 
 export default function Pools() {
   const { data } = useQuery({
     queryKey: ['pools'],
-    queryFn: async () => {
-      const res = await fetch('/api/candidates', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      });
-      return res.json();
-    },
+    queryFn: () => fetchCandidates({} as any),
   });
 
   const quotes = data?.candidates ?? [];

--- a/src/pages/Simulator.tsx
+++ b/src/pages/Simulator.tsx
@@ -2,18 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import CandidateTable, { Candidate } from '../components/CandidateTable';
 import SimulatorPanel from '../components/SimulatorPanel';
+import { fetchCandidates } from '../lib/api';
 
 export default function Simulator() {
   const { data } = useQuery({
     queryKey: ['candidates'],
-    queryFn: async () => {
-      const res = await fetch('/api/candidates', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      });
-      return res.json();
-    },
+    queryFn: () => fetchCandidates({} as any),
   });
 
   const [selected, setSelected] = useState<Candidate | null>(null);


### PR DESCRIPTION
## Summary
- add reusable `fetchCandidates` and `simulate` API helpers
- refactor components to use new helpers instead of direct `fetch`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896c0523a44832a9e10094793f715c1