### PR TITLE
Handle mutation errors and serialize bigint inputs

### DIFF
--- a/src/components/ExecutionToggle.tsx
+++ b/src/components/ExecutionToggle.tsx
@@ -11,26 +11,37 @@ export default function ExecutionToggle() {
 
   const exec = useMutation({
     mutationFn: async (next: boolean) => {
-      const res = await fetch('/api/execute', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ enabled: next }),
-      });
-      return res.json();
+      try {
+        const res = await fetch('/api/execute', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ enabled: next }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(data.error);
+        }
+        return data;
+      } catch (err) {
+        throw err;
+      }
     },
   });
 
   if (enabled) {
     return (
-      <button
-        onClick={() => {
-          dispatch(setEnabledAction(false));
-          exec.mutate(false);
-        }}
-        className="bg-red-500 text-white px-4 py-2 rounded"
-      >
-        Disable Execution
-      </button>
+      <div className="space-y-2">
+        <button
+          onClick={() => {
+            dispatch(setEnabledAction(false));
+            exec.mutate(false);
+          }}
+          className="bg-red-500 text-white px-4 py-2 rounded"
+        >
+          Disable Execution
+        </button>
+        {exec.error && <div className="error">{String(exec.error)}</div>}
+      </div>
     );
   }
 
@@ -43,17 +54,20 @@ export default function ExecutionToggle() {
         placeholder="Type ENABLE"
         className="border p-1 rounded text-black"
       />
-      <button
-        onClick={() => {
-          dispatch(setEnabledAction(true));
-          exec.mutate(true);
-          setConfirm('');
-        }}
-        disabled={confirm !== 'ENABLE'}
-        className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50"
-      >
-        Enable Execution
-      </button>
+      <div className="space-y-2">
+        <button
+          onClick={() => {
+            dispatch(setEnabledAction(true));
+            exec.mutate(true);
+            setConfirm('');
+          }}
+          disabled={confirm !== 'ENABLE'}
+          className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50"
+        >
+          Enable Execution
+        </button>
+        {exec.error && <div className="error">{String(exec.error)}</div>}
+      </div>
     </div>
   );
 }

--- a/src/components/SettingsForm.tsx
+++ b/src/components/SettingsForm.tsx
@@ -13,7 +13,12 @@ export default function SettingsForm() {
 
   const save = useMutation({
     mutationFn: () =>
-      fetchCandidates({ token0, token1, venue, amount } as any),
+      fetchCandidates({
+        token0,
+        token1,
+        venue,
+        amount: String(amount),
+      } as any),
   });
 
   return (
@@ -43,6 +48,7 @@ export default function SettingsForm() {
       <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
         Save
       </button>
+      {save.error && <div className="error">{String(save.error)}</div>}
       {save.data && <div className="text-sm text-gray-500">Saved</div>}
     </form>
   );

--- a/src/components/StrategyEditor.tsx
+++ b/src/components/StrategyEditor.tsx
@@ -8,12 +8,20 @@ export default function StrategyEditor() {
   const enabled = useSelector((state: RootState) => state.execution.enabled);
   const save = useMutation({
     mutationFn: async () => {
-      const res = await fetch('/api/execute', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ strategy: text }),
-      });
-      return res.json();
+      try {
+        const res = await fetch('/api/execute', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ strategy: text }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(data.error);
+        }
+        return data;
+      } catch (err) {
+        throw err;
+      }
     },
   });
 
@@ -38,6 +46,7 @@ export default function StrategyEditor() {
       >
         Save
       </button>
+      {save.error && <div className="error">{String(save.error)}</div>}
       {save.data && <div className="text-sm text-gray-500">Saved</div>}
     </form>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,10 +1,15 @@
 import { TCandidatesInput, TSimulateInput } from '../shared/validation';
 
+const json = (input: any) =>
+  JSON.stringify(input, (_, v) =>
+    typeof v === 'bigint' ? v.toString() : v
+  );
+
 export async function fetchCandidates(input: TCandidatesInput) {
   const res = await fetch('/api/candidates', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(input),
+    body: json(input),
   });
   const data = await res.json();
   if (!res.ok) {
@@ -17,7 +22,7 @@ export async function simulate(input: TSimulateInput) {
   const res = await fetch('/api/simulate', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(input),
+    body: json(input),
   });
   const data = await res.json();
   if (!res.ok) {

--- a/src/pages/Simulator.tsx
+++ b/src/pages/Simulator.tsx
@@ -5,7 +5,7 @@ import SimulatorPanel from '../components/SimulatorPanel';
 import { fetchCandidates } from '../lib/api';
 
 export default function Simulator() {
-  const { data } = useQuery({
+  const { data, error } = useQuery({
     queryKey: ['candidates'],
     queryFn: () => fetchCandidates({} as any),
   });
@@ -15,6 +15,7 @@ export default function Simulator() {
 
   return (
     <div className="p-4 grid gap-4 md:grid-cols-2">
+      {error && <div className="error">{String(error)}</div>}
       <CandidateTable candidates={candidates} onSelect={setSelected} />
       {selected && <SimulatorPanel candidate={selected} />}
     </div>


### PR DESCRIPTION
## Summary
- surface simulator and execution errors, catching failures in mutations
- show query and form errors in simulator and related components
- stringify bigint inputs before API calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896c1f2579c832a85b0bf17ac9aec7e