### PR TITLE
Validate candidate venues as strings

### DIFF
--- a/server/schemas.ts
+++ b/server/schemas.ts
@@ -1,15 +1,12 @@
 import { z } from 'zod';
 import {
+  CandidateSchema,
   CandidatesInput,
   SimulateInput,
   TCandidatesInput,
 } from '../src/shared/validation';
 
-export const candidateSchema = z.object({
-  buy: z.string(),
-  sell: z.string(),
-  profitUsd: z.number(),
-});
+export const candidateSchema = CandidateSchema;
 
 export const candidatesRequestSchema = CandidatesInput;
 export const candidatesResponseSchema = z.object({

--- a/src/shared/validation/schemas.test.ts
+++ b/src/shared/validation/schemas.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { CandidatesInput } from './schemas';
+import { CandidatesInput, SimulateInput } from './schemas';
 
 const validPayload = {
   providerUrl: 'https://example.com',
@@ -38,5 +38,27 @@ test('CandidatesInput rejects invalid address and missing fields', () => {
   expect(result.success).toBe(false);
   expect(result.error?.issues.some(i => i.path.join('.') === 'providerUrl')).toBe(true);
   expect(result.error?.issues.some(i => i.path.join('.') === 'venues.0.address')).toBe(true);
+});
+
+const validSimulatePayload = {
+  candidate: { buy: 'A', sell: 'B', profitUsd: 1 },
+  params: validPayload
+};
+
+test('SimulateInput accepts valid candidate', () => {
+  const result = SimulateInput.safeParse(validSimulatePayload);
+  expect(result.success).toBe(true);
+});
+
+test('SimulateInput rejects non-string venues', () => {
+  const invalidPayload: any = {
+    candidate: { buy: 123, sell: 456, profitUsd: 1 },
+    params: validPayload
+  };
+
+  const result = SimulateInput.safeParse(invalidPayload);
+  expect(result.success).toBe(false);
+  expect(result.error?.issues.some(i => i.path.join('.') === 'candidate.buy')).toBe(true);
+  expect(result.error?.issues.some(i => i.path.join('.') === 'candidate.sell')).toBe(true);
 });
 

--- a/src/shared/validation/schemas.ts
+++ b/src/shared/validation/schemas.ts
@@ -27,15 +27,18 @@ export const CandidatesInput = z.object({
   minProfitUsd: z.number().optional().default(0),
 });
 
+export const CandidateSchema = z.object({
+  buy: z.string(),
+  sell: z.string(),
+  profitUsd: z.number(),
+});
+
 export const SimulateInput = z.object({
-  candidate: z.object({
-    buy: BigintString,
-    sell: BigintString,
-    profitUsd: z.number(),
-  }),
+  candidate: CandidateSchema,
   params: CandidatesInput,
 });
 
 export type TCandidatesInput = z.infer<typeof CandidatesInput>;
 export type TSimulateInput = z.infer<typeof SimulateInput>;
+export type TCandidate = z.infer<typeof CandidateSchema>;
 


### PR DESCRIPTION
## Summary
- Add `CandidateSchema` with `buy`/`sell` as string venue names
- Use shared `CandidateSchema` on server
- Test valid and invalid simulate candidate payloads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896cf9607cc832abc1d8ba99bf39cb6