### PR TITLE
refactor: rename q98 helper to toQ96

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env ts-node
 import { JsonRpcProvider } from 'ethers';
 import dotenv from 'dotenv';
-import { q98 } from './src/utils/fixed';
+import { toQ96 } from './src/utils/fixed';
 import { buildCandidates, simulateCandidate } from './src/core/arbitrage';
 import type { VenueConfig } from './src/core/candidates';
 
@@ -36,8 +36,8 @@ async function main() {
   const ethUsd = Number(getArg('eth-usd') ?? getEnv('ETH_USD') ?? '0');
   const minProfitUsd = Number(getArg('min-profit-usd') ?? getEnv('MIN_PROFIT_USD') ?? '0');
 
-  const token0 = { decimals: token0Decimals, priceUsd: q98(token0Price) };
-  const token1 = { decimals: token1Decimals, priceUsd: q98(token1Price) };
+  const token0 = { decimals: token0Decimals, priceUsd: toQ96(token0Price) };
+  const token1 = { decimals: token1Decimals, priceUsd: toQ96(token1Price) };
 
   const candidates = await buildCandidates({
     provider,

--- a/src/core/arbitrage.test.ts
+++ b/src/core/arbitrage.test.ts
@@ -2,7 +2,7 @@ import { afterEach, expect, test, vi } from 'vitest';
 import { buildCandidates, simulateCandidate } from './arbitrage';
 import * as v2 from './v2';
 import * as v3 from './v3';
-import { q98 } from '../utils/fixed';
+import { toQ96 } from '../utils/fixed';
 
 const provider = {
   getFeeData: async () => ({ gasPrice: 1n * 10n ** 9n })
@@ -39,8 +39,8 @@ test('simulateCandidate recomputes profit', async () => {
     provider,
     venues,
     amountIn: 1n * 10n ** 18n,
-    token0: { decimals: 18, priceUsd: q98(2000) },
-    token1: { decimals: 6, priceUsd: q98(1) },
+    token0: { decimals: 18, priceUsd: toQ96(2000) },
+    token1: { decimals: 6, priceUsd: toQ96(1) },
     slippageBps: 0,
     gasUnits: 100000n,
     ethUsd: 2000,

--- a/src/core/candidates.test.ts
+++ b/src/core/candidates.test.ts
@@ -2,7 +2,7 @@ import { afterEach, expect, test, vi } from 'vitest';
 import { fetchCandidates } from './candidates';
 import * as v2 from './v2';
 import * as v3 from './v3';
-import { q98 } from '../utils/fixed';
+import { toQ96 } from '../utils/fixed';
 
 const provider = {
   getFeeData: async () => ({ gasPrice: 1n * 10n ** 9n })
@@ -37,8 +37,8 @@ test('fetchCandidates computes profit and filters by minProfitUsd', async () => 
       { name: 'B', type: 'v3', address: '0x2' }
     ],
     amountIn: 1n * 10n ** 18n,
-    token0: { decimals: 18, priceUsd: q98(2000) },
-    token1: { decimals: 6, priceUsd: q98(1) },
+    token0: { decimals: 18, priceUsd: toQ96(2000) },
+    token1: { decimals: 6, priceUsd: toQ96(1) },
     slippageBps: 0,
     gasUnits: 100000n,
     ethUsd: 2000,
@@ -76,8 +76,8 @@ test('returns empty array when profit below threshold', async () => {
       { name: 'B', type: 'v3', address: '0x2' }
     ],
     amountIn: 1n * 10n ** 18n,
-    token0: { decimals: 18, priceUsd: q98(2000) },
-    token1: { decimals: 6, priceUsd: q98(1) },
+    token0: { decimals: 18, priceUsd: toQ96(2000) },
+    token1: { decimals: 6, priceUsd: toQ96(1) },
     slippageBps: 0,
     gasUnits: 100000n,
     ethUsd: 2000,
@@ -113,8 +113,8 @@ test('handles amountIn larger than Number.MAX_SAFE_INTEGER', async () => {
       { name: 'B', type: 'v3', address: '0x2' }
     ],
     amountIn: hugeAmount,
-    token0: { decimals: 18, priceUsd: q98(2000) },
-    token1: { decimals: 6, priceUsd: q98(1) },
+    token0: { decimals: 18, priceUsd: toQ96(2000) },
+    token1: { decimals: 6, priceUsd: toQ96(1) },
     slippageBps: 0,
     gasUnits: 100000n,
     ethUsd: 2000,

--- a/src/utils/fixed.ts
+++ b/src/utils/fixed.ts
@@ -1,16 +1,18 @@
+/**
+ * 2^96 scaling factor used for Q64.96 fixed-point numbers.
+ */
 export const Q96 = 1n << 96n;
 
 /**
- * Converts an integer value to Q64.96 fixed-point format.
- * This is referenced as `q98` to provide a short helper
- * for working with Q64.96 numbers.
+ * Converts an integer to Q64.96 fixed-point format by multiplying by 2^96.
  */
-export function q98(value: bigint | number): bigint {
+export function toQ96(value: bigint | number): bigint {
   return BigInt(value) * Q96;
 }
 
 /**
- * Converts a Q64.96 value back to a JavaScript number.
+ * Converts a Q64.96 fixed-point value back to a JavaScript number by dividing
+ * by 2^96.
  */
 export function fromQ96(value: bigint): number {
   return Number(value) / Number(Q96);


### PR DESCRIPTION
## Summary
- rename q98 helper to toQ96 for Q64.96 fixed-point conversions
- adjust CLI and tests to use toQ96
- clarify comments around fixed-point conversion utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896d098795c832ab7f16e011eddb3fb