### PR TITLE
feat(server): type simulate params

### DIFF
--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1,0 +1,24 @@
+import { expect, expectTypeOf, test } from 'vitest';
+import { buildSimulateParams } from './index';
+import type { Candidate } from '../src/core/candidates';
+import type { CandidateParamsInput } from './schemas';
+import type { SimulateCandidateParams } from '../src/core/arbitrage';
+
+test('buildSimulateParams returns SimulateCandidateParams', () => {
+  const body: CandidateParamsInput = {
+    providerUrl: 'http://localhost:8545',
+    venues: [],
+    amountIn: '1',
+    token0: { decimals: 18, priceUsd: '1' },
+    token1: { decimals: 6, priceUsd: '1' },
+    slippageBps: 0,
+    gasUnits: '21000',
+    ethUsd: 1000,
+    minProfitUsd: 0,
+  };
+  const candidate: Candidate = { buy: 'A', sell: 'B', profitUsd: 0 };
+  const params = buildSimulateParams(body, candidate);
+  expect(params.candidate).toEqual(candidate);
+  expect((params as any).minProfitUsd).toBeUndefined();
+  expectTypeOf(params).toEqualTypeOf<SimulateCandidateParams>();
+});


### PR DESCRIPTION
## Summary
- type server simulation params and import SimulateCandidateParams
- expose helper to construct simulation params for tests
- add unit test for simulate params

## Testing
- `npx tsc server/index.ts server/index.test.ts --noEmit 2>&1 | tail -n 20`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896d1f3b7d4832aa659c8bfda09fe5d