### PR TITLE
Use VITE prefix for client environment variables

### DIFF
--- a/.env.client
+++ b/.env.client
@@ -1,6 +1,6 @@
 # Client environment variables
-# Only non-secret vars prefixed with REACT_APP_ are exposed to the browser
-REACT_APP_API_URL=http://localhost:3001
-REACT_APP_SLIPPAGE_BPS=50
-REACT_APP_GAS_CEILING=300000
-REACT_APP_MIN_PROFIT_USD=10
+# Only non-secret vars prefixed with VITE_ are exposed to the browser
+VITE_API_URL=http://localhost:3001
+VITE_SLIPPAGE_BPS=50
+VITE_GAS_CEILING=300000
+VITE_MIN_PROFIT_USD=10

--- a/README.md
+++ b/README.md
@@ -161,13 +161,13 @@ npm test     # run unit tests
 ```
 
 ### Environment Variables
-Non‑secret variables prefixed with `REACT_APP_` are exposed to the browser. Example `.env.client`:
+Non‑secret variables prefixed with `VITE_` are exposed to the browser. Example `.env.client`:
 
 ```
-REACT_APP_API_URL=http://localhost:3001
-REACT_APP_SLIPPAGE_BPS=50
-REACT_APP_GAS_CEILING=300000
-REACT_APP_MIN_PROFIT_USD=10
+VITE_API_URL=http://localhost:3001
+VITE_SLIPPAGE_BPS=50
+VITE_GAS_CEILING=300000
+VITE_MIN_PROFIT_USD=10
 ```
 
 ### Execution Modes

--- a/src/store/executionSlice.ts
+++ b/src/store/executionSlice.ts
@@ -8,10 +8,10 @@ interface ExecutionState {
 }
 
 const initialState: ExecutionState = {
-  enabled: process.env.REACT_APP_EXECUTION_ENABLED === 'true',
-  slippageBps: Number(process.env.REACT_APP_SLIPPAGE_BPS ?? 0),
-  gasCeiling: Number(process.env.REACT_APP_GAS_CEILING ?? 0),
-  minProfitUsd: Number(process.env.REACT_APP_MIN_PROFIT_USD ?? 0),
+  enabled: import.meta.env.VITE_EXECUTION_ENABLED === 'true',
+  slippageBps: Number(import.meta.env.VITE_SLIPPAGE_BPS ?? 0),
+  gasCeiling: Number(import.meta.env.VITE_GAS_CEILING ?? 0),
+  minProfitUsd: Number(import.meta.env.VITE_MIN_PROFIT_USD ?? 0),
 };
 
 const executionSlice = createSlice({


### PR DESCRIPTION
## Summary
- rename REACT_APP_ variables to VITE_ in .env.client
- reference VITE_* through `import.meta.env` in execution slice
- document VITE_ prefix in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896f678a1e8832abf0b10e99c85bc98