### PR TITLE
Use bigint profit math and add large-number tests

### DIFF
--- a/src/core/arbitrage.test.ts
+++ b/src/core/arbitrage.test.ts
@@ -64,3 +64,57 @@ test('simulateCandidate recomputes profit', async () => {
 
   expect(sim.profitUsd).toBeCloseTo(candidates[0].profitUsd, 2);
 });
+
+test('simulateCandidate handles amountIn larger than Number.MAX_SAFE_INTEGER', async () => {
+  vi.spyOn(v2, 'getV2Quote').mockResolvedValue({
+    token0: '',
+    token1: '',
+    reserve0: 0n,
+    reserve1: 0n,
+    price0: 100,
+    price1: 0
+  });
+  vi.spyOn(v3, 'getV3Quote').mockResolvedValue({
+    token0: '',
+    token1: '',
+    sqrtPriceX96: 0n,
+    tick: 0,
+    fee: 0,
+    price: 105
+  });
+
+  const venues = [
+    { name: 'A', type: 'v2' as const, address: '0x1' },
+    { name: 'B', type: 'v3' as const, address: '0x2' }
+  ];
+
+  const amountIn = (BigInt(Number.MAX_SAFE_INTEGER) + 1n) * 10n ** 18n;
+  const params = {
+    provider,
+    venues,
+    amountIn,
+    token0: { address: '0x0000000000000000000000000000000000000001', decimals: 18, priceUsd: toQ96(2000) },
+    token1: { address: '0x0000000000000000000000000000000000000002', decimals: 6, priceUsd: toQ96(1) },
+    slippageBps: 0,
+    gasUnits: 100000n,
+    ethUsd: 2000,
+    minProfitUsd: 1
+  };
+
+  const candidates = await buildCandidates(params);
+  expect(candidates).toHaveLength(1);
+
+  const sim = await simulateCandidate({
+    candidate: candidates[0],
+    provider,
+    venues,
+    amountIn,
+    token0: params.token0,
+    token1: params.token1,
+    slippageBps: params.slippageBps,
+    gasUnits: params.gasUnits,
+    ethUsd: params.ethUsd
+  });
+
+  expect(Number.isFinite(sim.profitUsd)).toBe(true);
+});

--- a/src/core/arbitrage.ts
+++ b/src/core/arbitrage.ts
@@ -2,7 +2,7 @@ import { type Provider, parseUnits } from 'ethers';
 import { fetchCandidates, type Candidate, type CandidateParams, type VenueConfig } from './candidates';
 import { getV2Quote } from './v2';
 import { getV3Quote } from './v3';
-import { fromQ96 } from '../utils/fixed';
+import { fromQ96, toQ96 } from '../utils/fixed';
 import { estimateGasUsd } from '../utils/gas';
 import type { TokenInfo } from '../utils/prices';
 
@@ -76,13 +76,9 @@ export async function simulateCandidate({
   const sellAdj = (sellPrice * (baseBps - slipBps)) / baseBps;
   const profitToken1 = ((sellAdj - buyAdj) * amountIn) / amountScale;
 
-  const whole = profitToken1 / priceScale;
-  const frac = profitToken1 % priceScale;
-  const profitToken1Num = Number(whole) + Number(frac) / Number(priceScale);
-
-  const token1Usd = fromQ96(token1.priceUsd);
+  const profitUsdQ96 = (profitToken1 * token1.priceUsd) / priceScale;
   const gasUsd = await estimateGasUsd({ provider, gasUnits, ethUsd });
-  const profitUsd = profitToken1Num * token1Usd - gasUsd;
+  const profitUsd = fromQ96(profitUsdQ96 - toQ96(gasUsd));
 
   return { buy: candidate.buy, sell: candidate.sell, profitUsd };
 }

--- a/src/utils/fixed.ts
+++ b/src/utils/fixed.ts
@@ -1,13 +1,20 @@
+import { parseUnits } from 'ethers';
+
 /**
  * 2^96 scaling factor used for Q64.96 fixed-point numbers.
  */
 export const Q96 = 1n << 96n;
 
 /**
- * Converts an integer to Q64.96 fixed-point format by multiplying by 2^96.
+ * Converts a numeric value to Q64.96 fixed-point format by multiplying by 2^96.
+ * Floating point numbers are converted using 18 decimals of precision.
  */
 export function toQ96(value: bigint | number): bigint {
-  return BigInt(value) * Q96;
+  if (typeof value === 'bigint') {
+    return value * Q96;
+  }
+  const scaled = parseUnits(value.toString(), 18);
+  return (scaled * Q96) / 10n ** 18n;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Maintain `profitToken1` calculations in bigint and convert to USD once with `fromQ96` after subtracting gas costs
- Allow `toQ96` to handle fractional inputs using 18-decimal scaling
- Add tests covering large `amountIn` values beyond `Number.MAX_SAFE_INTEGER`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68978e18f58c832aaf169ddc5567035d