### PR TITLE
Gracefully handle invalid venues JSON in CLI

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -21,7 +21,13 @@ async function main() {
   const provider = new JsonRpcProvider(rpc);
 
   const venuesJson = getArg('venues') ?? getEnv('VENUES') ?? '[]';
-  const venues: VenueConfig[] = JSON.parse(venuesJson);
+  let venues: VenueConfig[];
+  try {
+    venues = JSON.parse(venuesJson);
+  } catch {
+    console.error('Invalid venues JSON');
+    process.exit(1);
+  }
 
   const amountInStr = getArg('amount-in') ?? getEnv('AMOUNT_IN') ?? '0';
   const amountIn = BigInt(amountInStr);

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const cliPath = path.resolve(__dirname, "..", "cli.ts");
+const tsxPath = path.resolve(
+  __dirname,
+  "..",
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "tsx.cmd" : "tsx"
+);
+
+describe("cli", () => {
+  it("handles invalid venues JSON gracefully", () => {
+    const result = spawnSync(
+      tsxPath,
+      [cliPath, "--rpc=http://localhost:8545", "--venues=["],
+      { encoding: "utf-8" }
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Invalid venues JSON");
+  });
+});


### PR DESCRIPTION
## Summary
- guard venues parsing in `cli.ts` and exit with an error message when JSON is invalid
- add a vitest spec to verify CLI behavior for malformed venues JSON

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68978fd34b1c832aa150d732d58330d9