### PR TITLE
feat: track pool state and coalesce block snapshots

### DIFF
--- a/src/chain/multicall.ts
+++ b/src/chain/multicall.ts
@@ -1,0 +1,11 @@
+// Stub: replace with your multicall implementation
+import { setPoolState } from "./state";
+
+export async function batchSnapshot(addresses: string[]) {
+  if (!addresses.length) return;
+  // TODO: real multicall to fetch reserves/slot0
+  for (const a of addresses) {
+    // placeholders; replace with actual on-chain reads
+    setPoolState(a, { reserve0: 1_000_000n, reserve1: 1_000_000n, block: 0n });
+  }
+}

--- a/src/chain/state.ts
+++ b/src/chain/state.ts
@@ -1,0 +1,24 @@
+type V2State = { reserve0: bigint; reserve1: bigint; block: bigint };
+type V3State = { sqrtPriceX96: bigint; tick: number; block: bigint };
+export type PoolState = V2State | V3State;
+
+const state = new Map<string, PoolState>();
+const touched = new Set<string>();
+
+export function markTouched(addresses: string[]) {
+  addresses.forEach((a) => touched.add(a.toLowerCase()));
+}
+export function drainTouched(): string[] {
+  const list = Array.from(touched.values());
+  touched.clear();
+  return list;
+}
+export function setPoolState(addr: string, s: PoolState) {
+  state.set(addr.toLowerCase(), s);
+}
+export function getPoolState(addr: string): PoolState | undefined {
+  return state.get(addr.toLowerCase());
+}
+export function allStates() {
+  return Array.from(state.entries());
+}

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -1,0 +1,22 @@
+import { eventBus } from "./bus";
+import { markTouched, drainTouched } from "../chain/state";
+import { batchSnapshot } from "../chain/multicall";
+// import { computeCandidates, simulate } from "../core/strategyParts"; // your pure math pieces
+// import type { StrategyCtx } from "./context";
+
+export function wireEventBuffering() {
+  eventBus.on("v2:sync", (logs: any[]) => {
+    const addrs = logs.map((l) => l.address);
+    markTouched(addrs);
+  });
+  eventBus.on("v2:swap", (logs: any[]) => markTouched(logs.map((l) => l.address)));
+  eventBus.on("v3:swap", (logs: any[]) => markTouched(logs.map((l) => l.address)));
+}
+
+export async function onBlockTick(/*ctx: StrategyCtx*/) {
+  const touched = drainTouched();
+  await batchSnapshot(touched);
+  // const candidates = computeCandidates(ctx, /* read state */);
+  // const winners = candidates.filter(...); // slippage & gas
+  // winners.forEach((w) => eventBus.emit("candidate", w));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,18 @@
 import { normalizeStartup } from './core/context';
 import { runLoop } from './core/strategy';
 import { loadConfig } from './utils/config';
+import { startChainWS } from './chain/wsClient';
+import { wireEventBuffering, onBlockTick } from './core/loop';
+import { eventBus } from './core/bus';
 
 async function start() {
+  wireEventBuffering();
+  const stopWS = startChainWS({ wsUrl: process.env.WS_RPC!, shards: 2 });
+
+  eventBus.on("block", async () => {
+    try { await onBlockTick(); } catch (e) { eventBus.emit("log", { level: "error", msg: String(e) }); }
+  });
+
   const raw = await loadConfig();
   const ctx = normalizeStartup(raw);
   await runLoop(ctx);


### PR DESCRIPTION
## Summary
- track touched pools in memory and coalesce updates per block
- add multicall snapshot stub to refresh pool state
- wire WebSocket events to block-based compute loop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897a0b63a58832ab461a72d7b7de6b6