### PR TITLE
Handle SSE log and candidate events separately

### DIFF
--- a/src/components/LogStream.tsx
+++ b/src/components/LogStream.tsx
@@ -1,20 +1,31 @@
 import { useEffect, useState } from 'react';
 
+type StreamEvent =
+  | { type: 'log'; data: string }
+  | { type: 'candidate'; data: any };
+
 export default function LogStream() {
-  const [logs, setLogs] = useState<string[]>([]);
+  const [events, setEvents] = useState<StreamEvent[]>([]);
 
   useEffect(() => {
     const es = new EventSource('/api/stream');
-    es.onmessage = (e) => {
-      setLogs((l) => [...l, e.data]);
-    };
+    es.addEventListener('log', (e) => {
+      const data = JSON.parse((e as MessageEvent).data);
+      setEvents((l) => [...l, { type: 'log', data }]);
+    });
+    es.addEventListener('candidate', (e) => {
+      const data = JSON.parse((e as MessageEvent).data);
+      setEvents((l) => [...l, { type: 'candidate', data }]);
+    });
     return () => es.close();
   }, []);
 
   return (
     <div className="bg-black text-green-400 p-4 font-mono h-96 overflow-y-auto">
-      {logs.map((l, i) => (
-        <div key={i}>{l}</div>
+      {events.map((e, i) => (
+        <div key={i}>
+          {e.type === 'log' ? e.data : JSON.stringify(e.data)}
+        </div>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- listen to `log` and `candidate` SSE events in `LogStream`
- track streamed event types in state and render accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897a7fafdd0832a9ae622fe24a63b73