### PR TITLE
feat: add flashbots relay integration

### DIFF
--- a/src/core/execute.ts
+++ b/src/core/execute.ts
@@ -1,3 +1,26 @@
-export async function executeTrade(_input: unknown): Promise<unknown> {
-  return { ok: true };
+import { FlashbotsRelay } from "../exec/relays/flashbots";
+import { executeWithRelay } from "../exec/submit";
+import type { Relay, ExecResult } from "../exec/submit";
+
+/**
+ * Execute a trade via the configured Flashbots relay.
+ *
+ * RPC URL and bundle signer key are read from environment variables
+ * `FLASHBOTS_RPC_URL` and `FLASHBOTS_SIGNER_KEY` respectively. Errors from the
+ * relay are captured and returned so callers can handle them without throwing.
+ */
+export async function executeTrade(
+  p: Parameters<Relay["sendPrivateTx"]>[0]
+): Promise<ExecResult> {
+  const rpcUrl = process.env.FLASHBOTS_RPC_URL || "";
+  const bundleSignerKey = process.env.FLASHBOTS_SIGNER_KEY || "";
+  const relay = new FlashbotsRelay({ rpcUrl, bundleSignerKey });
+
+  try {
+    return await executeWithRelay(relay, p);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: msg };
+  }
 }
+

--- a/src/exec/relays/flashbots.ts
+++ b/src/exec/relays/flashbots.ts
@@ -1,10 +1,61 @@
-import type { Relay } from "../submit";
+import type { Relay, ExecResult } from "../submit";
+import { JsonRpcProvider, Wallet } from "ethers";
 
+/**
+ * Relay for sending transactions through Flashbots/builder.
+ *
+ * The relay requires a JSON-RPC endpoint and a bundle signer key. Both should
+ * point to a Flashbots/builder compatible endpoint. Failures are caught and
+ * returned as { ok: false, error } so that callers can handle them gracefully
+ * without throwing.
+ */
 export class FlashbotsRelay implements Relay {
   constructor(private opts: { rpcUrl: string; bundleSignerKey: string }) {}
-  async sendPrivateTx(p: Parameters<Relay["sendPrivateTx"]>[0]) {
-    // TODO: integrate with your Flashbots/builder SDK.
-    // This is a stub. Return an ok=false with message for now.
-    return { ok: false, error: "Flashbots integration not yet configured" };
+
+  async sendPrivateTx(
+    p: Parameters<Relay["sendPrivateTx"]>[0]
+  ): Promise<ExecResult> {
+    try {
+      // Initialize provider & signer
+      const provider = new JsonRpcProvider(this.opts.rpcUrl);
+      const signer = new Wallet(this.opts.bundleSignerKey, provider);
+
+      const txRequest = {
+        to: signer.address,
+        data: p.routeCalldata,
+        maxFeePerGas: p.maxFeePerGas,
+        maxPriorityFeePerGas: p.maxPriorityFeePerGas,
+      } as const;
+
+      // Sign and send the transaction as a private tx via Flashbots relay.
+      const signed = await signer.signTransaction(txRequest);
+      const body = {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_sendRawTransaction",
+        params: [signed],
+      };
+
+      const signature = await signer.signMessage(
+        Buffer.from(JSON.stringify(body))
+      );
+
+      const res = await fetch(this.opts.rpcUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Flashbots-Signature": `${signer.address}:${signature}`,
+        },
+        body: JSON.stringify(body),
+      });
+
+      const json: any = await res.json();
+      if (json.error) return { ok: false, error: json.error.message };
+      return { ok: true, txHash: json.result };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: msg };
+    }
   }
 }
+


### PR DESCRIPTION
## Summary
- connect Flashbots relay to sign and send private transactions
- execute trades through Flashbots with env-configured RPC and signer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897acb6c2e0832a8cbc62de7f7a7a31