### PR TITLE
feat: validate and persist settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ yarn-error.log*
 
 # build artifacts
 /dist
+settings.json

--- a/src/core/settings.test.ts
+++ b/src/core/settings.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, expect, test } from 'vitest';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { saveSettings, type Settings } from './settings';
+
+let tmpFile: string | null = null;
+
+afterEach(async () => {
+  if (tmpFile) {
+    try { await fs.unlink(tmpFile); } catch {}
+    tmpFile = null;
+  }
+  delete process.env.SETTINGS_FILE;
+});
+
+test('saves valid settings to file', async () => {
+  tmpFile = join(tmpdir(), `settings-${Date.now()}.json`);
+  process.env.SETTINGS_FILE = tmpFile;
+
+  const input: Settings = {
+    chainId: 1,
+    rpcUrl: 'http://localhost',
+    minProfitUsd: 1,
+    slippageBps: 10,
+    gasUnits: '21000'
+  };
+
+  const result = await saveSettings(input);
+  expect(result).toEqual({ success: true, data: input });
+  const stored = JSON.parse(await fs.readFile(tmpFile, 'utf8'));
+  expect(stored).toEqual(input);
+});
+
+test('returns error for invalid settings', async () => {
+  tmpFile = join(tmpdir(), `settings-${Date.now()}-invalid.json`);
+  process.env.SETTINGS_FILE = tmpFile;
+  const result = await saveSettings({ chainId: 0 });
+  expect(result.success).toBe(false);
+});

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -1,3 +1,33 @@
-export async function saveSettings(input: unknown): Promise<unknown> {
-  return { saved: true, ...((typeof input === 'object' && input) || {}) };
+import { promises as fs } from "fs";
+import path from "path";
+import { z } from "zod";
+
+const settingsSchema = z.object({
+  chainId: z.number().int().positive(),
+  rpcUrl: z.string().url(),
+  minProfitUsd: z.number().positive(),
+  slippageBps: z.number().min(0).max(2000),
+  gasUnits: z.string().regex(/^\d+$/),
+});
+
+export type Settings = z.infer<typeof settingsSchema>;
+
+const defaultFile = path.resolve(__dirname, "../../settings.json");
+
+export async function saveSettings(
+  input: unknown
+): Promise<{ success: true; data: Settings } | { success: false; error: string }> {
+  const result = settingsSchema.safeParse(input);
+  if (!result.success) {
+    const issues = (result.error as any).issues || (result.error as any).errors || [];
+    const error = issues.map((e: any) => e.message).join(", ");
+    return { success: false, error };
+  }
+  const filePath = process.env.SETTINGS_FILE ?? defaultFile;
+  try {
+    await fs.writeFile(filePath, JSON.stringify(result.data, null, 2), "utf8");
+    return { success: true, data: result.data };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
 }


### PR DESCRIPTION
## Summary
- validate settings payload with zod
- persist settings to JSON and handle storage errors
- add tests covering settings persistence and invalid input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b5a4c6f0832a8fc7b5186da2cfa4