### PR TITLE
feat: add heartbeat and block events to stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ curl -X POST http://localhost:3001/api/execute \
 ```
 
 ### `GET /api/stream`
-Server-Sent Events stream providing live `block`, `quote`, `candidates`, and periodic `heartbeat` messages.
+Server-Sent Events stream providing live `block`, `candidate`, and periodic `heartbeat` messages every 15 seconds.
 
 ```bash
 curl -N http://localhost:3001/api/stream

--- a/server/stream.ts
+++ b/server/stream.ts
@@ -1,6 +1,8 @@
 import type { Request, Response } from "express";
 import { eventBus } from "../src/core/bus";
 
+const HEARTBEAT_MS = 15_000;
+
 export function stream(req: Request, res: Response) {
   res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache");
@@ -13,12 +15,18 @@ export function stream(req: Request, res: Response) {
 
   const onCand = (c: any) => push("candidate", c);
   const onLog = (m: any) => push("log", m);
+  const onBlock = (b: any) => push("block", b);
+
+  const hb = setInterval(() => push("heartbeat", Date.now()), HEARTBEAT_MS);
 
   eventBus.on("candidate", onCand);
   eventBus.on("log", onLog);
+  eventBus.on("block", onBlock);
 
   req.on("close", () => {
+    clearInterval(hb);
     eventBus.off("candidate", onCand);
     eventBus.off("log", onLog);
+    eventBus.off("block", onBlock);
   });
 }


### PR DESCRIPTION
## Summary
- forward `block` events to SSE stream and send heartbeat every 15s
- document stream events and heartbeat cadence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897bf8c82d0832a9829add74572d657