### PR TITLE
Require server env vars and document execution configuration

### DIFF
--- a/.env.server
+++ b/.env.server
@@ -3,3 +3,6 @@
 PORT=3001
 RPC_URL=http://localhost:8545
 AUTH_TOKEN=changeme
+EXEC_ENABLED=0
+WS_RPC=ws://localhost:8545
+BUNDLE_SIGNER_KEY=changeme

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ MIN_PROFIT_USD	Minimum USD profit required to trade
 SLIPPAGE_BPS	Slippage tolerance in basis points
 AUTH_TOKEN      Bearer token required for `/api/execute`; requests missing or
                 with invalid `Authorization` headers receive a 401 response
+EXEC_ENABLED    Set to `1` to enable `/api/execute`; requires `WS_RPC` and
+                `BUNDLE_SIGNER_KEY`
+WS_RPC          WebSocket RPC endpoint for transaction submission; required
+                when `EXEC_ENABLED=1`
+BUNDLE_SIGNER_KEY Private key for signing bundles; required when
+                `EXEC_ENABLED=1`
 Usage
 CLI
 Run simple candidate discovery & simulation:
@@ -120,9 +126,11 @@ curl -X POST http://localhost:3001/api/simulate \
 
 ### `POST /api/execute`
 Runs the engine with the provided parameters. The server fails to start unless the
-`AUTH_TOKEN` environment variable is set, and requests must include the same value
-via an `Authorization: Bearer` header. Requests without the correct token receive
-an immediate `401 Unauthorized` response before payload validation.
+`AUTH_TOKEN` environment variable is set. When `EXEC_ENABLED=1`, the `WS_RPC` and
+`BUNDLE_SIGNER_KEY` variables must also be configured. Requests must include the
+`AUTH_TOKEN` value via an `Authorization: Bearer` header. Requests without the
+correct token receive an immediate `401 Unauthorized` response before payload
+validation.
 
 **Example**
 

--- a/server/__tests__/api.test.ts
+++ b/server/__tests__/api.test.ts
@@ -52,7 +52,7 @@ describe('API endpoints', () => {
   beforeEach(async () => {
     vi.resetModules();
     delete process.env.EXEC_ENABLED;
-    delete process.env.AUTH_TOKEN;
+    process.env.AUTH_TOKEN = 't';
     vi.doMock('../../src/core/candidates', () => {
       const fetchCandidates = vi.fn(async () => [
         { buy: 'A', sell: 'B', profitUsd: 1 },
@@ -100,6 +100,8 @@ describe('API endpoints', () => {
     vi.resetModules();
     process.env.EXEC_ENABLED = '1';
     process.env.AUTH_TOKEN = 't';
+    process.env.WS_RPC = 'ws://localhost';
+    process.env.BUNDLE_SIGNER_KEY = '0xabc';
     ({ default: app } = await import('../index'));
     const res = await request(app).post('/api/execute').send(execParams);
     expect(res.status).toBe(401);
@@ -118,6 +120,8 @@ describe('API endpoints', () => {
     vi.doMock('../../index', () => ({ __esModule: true, default: vi.fn(async () => {}) }));
     process.env.EXEC_ENABLED = '1';
     process.env.AUTH_TOKEN = 't';
+    process.env.WS_RPC = 'ws://localhost';
+    process.env.BUNDLE_SIGNER_KEY = '0xabc';
     ({ default: app } = await import('../index'));
     const res = await request(app)
       .post('/api/execute')

--- a/server/__tests__/env.test.ts
+++ b/server/__tests__/env.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect, vi } from 'vitest';
+
+const importServer = () => import('../index');
+
+describe('environment variables', () => {
+  test('exits when AUTH_TOKEN is missing', async () => {
+    vi.resetModules();
+    delete process.env.AUTH_TOKEN;
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(String(code));
+    }) as any);
+    await expect(importServer()).rejects.toThrow('1');
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  test('exits when EXEC_ENABLED=1 but WS_RPC missing', async () => {
+    vi.resetModules();
+    process.env.AUTH_TOKEN = 't';
+    process.env.EXEC_ENABLED = '1';
+    delete process.env.WS_RPC;
+    delete process.env.BUNDLE_SIGNER_KEY;
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(String(code));
+    }) as any);
+    await expect(importServer()).rejects.toThrow('1');
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+
+  test('exits when EXEC_ENABLED=1 but BUNDLE_SIGNER_KEY missing', async () => {
+    vi.resetModules();
+    process.env.AUTH_TOKEN = 't';
+    process.env.EXEC_ENABLED = '1';
+    process.env.WS_RPC = 'ws://localhost';
+    delete process.env.BUNDLE_SIGNER_KEY;
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(String(code));
+    }) as any);
+    await expect(importServer()).rejects.toThrow('1');
+    expect(exit).toHaveBeenCalledWith(1);
+    exit.mockRestore();
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,22 @@ import { stream } from "./stream";
 import { execute } from "./routes/execute";
 import { register } from "../src/utils/metrics";
 
+const requireEnv = (name: string) => {
+  const v = process.env[name];
+  if (!v) {
+    // eslint-disable-next-line no-console
+    console.error(`Missing required environment variable ${name}`);
+    process.exit(1);
+  }
+  return v;
+};
+
+requireEnv("AUTH_TOKEN");
+if (process.env.EXEC_ENABLED === "1") {
+  requireEnv("WS_RPC");
+  requireEnv("BUNDLE_SIGNER_KEY");
+}
+
 const wrap = <T>(schema: { safeParse: (v: unknown) => { success: boolean; data?: T; error?: { message: string } } }) => (v: unknown) => {
   const r = schema.safeParse(v);
   return r.success ? { success: true, data: r.data as T } : { success: false, error: r.error?.message };


### PR DESCRIPTION
## Summary
- ensure server exits on missing AUTH_TOKEN and, when EXEC_ENABLED=1, require WS_RPC and BUNDLE_SIGNER_KEY
- document EXEC_ENABLED, WS_RPC and BUNDLE_SIGNER_KEY in README and `.env.server`
- add tests for missing or invalid environment variable combinations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897c0b86cd4832abd297e69583bd510