### PR TITLE
feat: add environment config parsing

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,3 +1,48 @@
-export async function loadConfig(): Promise<unknown> {
-  return {};
+import dotenv from 'dotenv';
+import { z } from 'zod';
+
+dotenv.config();
+
+const schema = z.object({
+  RPC_URL: z.string().url(),
+  PRIVATE_KEY: z.string().regex(/^0x[0-9a-fA-F]{64}$/),
+  CHAIN_ID: z.coerce.number().int().positive().default(1),
+  MIN_PROFIT_USD: z.coerce.number().nonnegative(),
+  SLIPPAGE_BPS: z.coerce.number().int().nonnegative(),
+  AUTH_TOKEN: z.string().optional(),
+  EXEC_ENABLED: z.enum(['0', '1']).optional(),
+  WS_RPC: z.string().url().optional(),
+  BUNDLE_SIGNER_KEY: z.string().regex(/^0x[0-9a-fA-F]{64}$/).optional()
+});
+
+export type Config = {
+  rpcUrl: string;
+  privateKey: string;
+  chainId: number;
+  minProfitUsd: number;
+  slippageBps: number;
+  authToken?: string;
+  execEnabled: boolean;
+  wsRpc?: string;
+  bundleSignerKey?: string;
+};
+
+export async function loadConfig(): Promise<Config> {
+  const parsed = schema.safeParse(process.env);
+  if (!parsed.success) {
+    const msg = parsed.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join(', ');
+    throw new Error(`Invalid environment variables: ${msg}`);
+  }
+  const env = parsed.data;
+  return {
+    rpcUrl: env.RPC_URL,
+    privateKey: env.PRIVATE_KEY,
+    chainId: env.CHAIN_ID,
+    minProfitUsd: env.MIN_PROFIT_USD,
+    slippageBps: env.SLIPPAGE_BPS,
+    authToken: env.AUTH_TOKEN,
+    execEnabled: env.EXEC_ENABLED === '1',
+    wsRpc: env.WS_RPC,
+    bundleSignerKey: env.BUNDLE_SIGNER_KEY
+  };
 }


### PR DESCRIPTION
## Summary
- build typed configuration loader using dotenv and zod
- validate RPC URL, signing keys and numeric limits
- expose `loadConfig` to provide a ready-to-use config object

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897c63ac490832ab18161ae419f2b52