### PR TITLE
Reuse FlashbotsRelay instance in execute route

### DIFF
--- a/server/routes/execute.ts
+++ b/server/routes/execute.ts
@@ -6,6 +6,11 @@ import { FlashbotsRelay } from "../../src/exec/relays/flashbots";
 const EXEC_ENABLED = process.env.EXEC_ENABLED === "1";
 const AUTH_TOKEN = process.env.AUTH_TOKEN || "";
 
+const relay = new FlashbotsRelay({
+  rpcUrl: process.env.WS_RPC || "",
+  bundleSignerKey: process.env.BUNDLE_SIGNER_KEY || ""
+});
+
 export async function execute(req: Request, res: Response) {
   if (!EXEC_ENABLED) return res.status(403).json({ error: "execution disabled" });
 
@@ -15,11 +20,6 @@ export async function execute(req: Request, res: Response) {
 
   const r = vSafe(ExecuteInput, req.body);
   if (!r.success) return res.status(400).json({ error: r.error });
-
-  const relay = new FlashbotsRelay({
-    rpcUrl: process.env.WS_RPC || "",
-    bundleSignerKey: process.env.BUNDLE_SIGNER_KEY || ""
-  });
 
   const out = await executeWithRelay(relay, {
     ...r.data,


### PR DESCRIPTION
## Summary
- Instantiate FlashbotsRelay once at module load and reuse in execute handler to avoid per-request setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897c95aa4fc832a9b203aad9d978e96