### PR TITLE
Handle fetch errors and malformed JSON responses

### DIFF
--- a/src/components/ExecutionToggle.tsx
+++ b/src/components/ExecutionToggle.tsx
@@ -17,11 +17,19 @@ export default function ExecutionToggle() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ enabled: next }),
         });
-        const data = await res.json();
         if (!res.ok) {
-          throw new Error(data.error);
+          try {
+            const err = await res.json();
+            throw new Error(err.error || res.statusText);
+          } catch {
+            throw new Error(res.statusText);
+          }
         }
-        return data;
+        try {
+          return await res.json();
+        } catch {
+          throw new Error('Malformed JSON response');
+        }
       } catch (err) {
         throw err;
       }

--- a/src/components/SimulatorPanel.tsx
+++ b/src/components/SimulatorPanel.tsx
@@ -37,11 +37,19 @@ export default function SimulatorPanel({ candidate }: { candidate: Candidate }) 
             (_, v) => (typeof v === 'bigint' ? v.toString() : v)
           ),
         });
-        const data = await res.json();
         if (!res.ok) {
-          throw new Error(data.error);
+          try {
+            const err = await res.json();
+            throw new Error(err.error || res.statusText);
+          } catch {
+            throw new Error(res.statusText);
+          }
         }
-        return data;
+        try {
+          return await res.json();
+        } catch {
+          throw new Error('Malformed JSON response');
+        }
       } catch (err) {
         throw err;
       }

--- a/src/components/StrategyEditor.tsx
+++ b/src/components/StrategyEditor.tsx
@@ -14,11 +14,19 @@ export default function StrategyEditor() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ strategy: text }),
         });
-        const data = await res.json();
         if (!res.ok) {
-          throw new Error(data.error);
+          try {
+            const err = await res.json();
+            throw new Error(err.error || res.statusText);
+          } catch {
+            throw new Error(res.statusText);
+          }
         }
-        return data;
+        try {
+          return await res.json();
+        } catch {
+          throw new Error('Malformed JSON response');
+        }
       } catch (err) {
         throw err;
       }

--- a/src/exec/relays/flashbots.ts
+++ b/src/exec/relays/flashbots.ts
@@ -48,10 +48,24 @@ export class FlashbotsRelay implements Relay {
         },
         body: JSON.stringify(body),
       });
+      if (!res.ok) {
+        try {
+          const err = await res.json();
+          const msg = err?.error?.message || res.statusText;
+          return { ok: false, error: msg };
+        } catch {
+          return { ok: false, error: res.statusText };
+        }
+      }
 
-      const json: any = await res.json();
-      if (json.error) return { ok: false, error: json.error.message };
-      return { ok: true, txHash: json.result };
+      try {
+        const json: any = await res.json();
+        if (json.error) return { ok: false, error: json.error.message };
+        return { ok: true, txHash: json.result };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: msg };
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return { ok: false, error: msg };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,11 +11,21 @@ export async function fetchCandidates(input: TCandidatesInput) {
     headers: { 'Content-Type': 'application/json' },
     body: json(input),
   });
-  const data = await res.json();
+
   if (!res.ok) {
-    throw new Error(data.error);
+    try {
+      const err = await res.json();
+      throw new Error(err.error || res.statusText);
+    } catch {
+      throw new Error(res.statusText);
+    }
   }
-  return data;
+
+  try {
+    return await res.json();
+  } catch {
+    throw new Error('Malformed JSON response');
+  }
 }
 
 export async function simulate(input: TSimulateInput) {
@@ -24,9 +34,19 @@ export async function simulate(input: TSimulateInput) {
     headers: { 'Content-Type': 'application/json' },
     body: json(input),
   });
-  const data = await res.json();
+
   if (!res.ok) {
-    throw new Error(data.error);
+    try {
+      const err = await res.json();
+      throw new Error(err.error || res.statusText);
+    } catch {
+      throw new Error(res.statusText);
+    }
   }
-  return data;
+
+  try {
+    return await res.json();
+  } catch {
+    throw new Error('Malformed JSON response');
+  }
 }


### PR DESCRIPTION
## Summary
- Check `Response.ok` before parsing JSON in API and UI fetches
- Guard `res.json()` in try/catch to surface malformed responses
- Return `ExecResult { ok:false, error }` for non-200 Flashbots RPC results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897ca618b70832aab2ace2c161aad5b