### PR TITLE
feat: exclude dev deps in client Docker build

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -3,7 +3,7 @@ FROM node:18-alpine AS build
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --omit=dev
 
 COPY public ./public
 COPY src ./src


### PR DESCRIPTION
## Summary
- avoid installing dev dependencies in client Docker image by adding `--omit=dev`

## Testing
- `npm run build` *(fails: sh: 1: vite: not found)*


------
https://chatgpt.com/codex/tasks/task_e_6897d01eb468832a8b98ef133fe8e8f1