### PR TITLE
Validate settings file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ AUTH_TOKEN      Bearer token required for `/api/execute`; requests missing or
                 with invalid `Authorization` headers receive a 401 response
 EXEC_ENABLED    Set to `1` to enable `/api/execute`; requires `WS_RPC` and
                 `BUNDLE_SIGNER_KEY`
-WS_RPC          WebSocket RPC endpoint for transaction submission; required
-                when `EXEC_ENABLED=1`
-BUNDLE_SIGNER_KEY Private key for signing bundles; required when
-                `EXEC_ENABLED=1`
-Usage
+  WS_RPC          WebSocket RPC endpoint for transaction submission; required
+                  when `EXEC_ENABLED=1`
+  BUNDLE_SIGNER_KEY Private key for signing bundles; required when
+                  `EXEC_ENABLED=1`
+  SETTINGS_FILE   Optional path to persist settings JSON. Must resolve within
+                  the project root; directories are created automatically and
+                  paths outside this base cause saving to fail.
+  Usage
 CLI
 Run simple candidate discovery & simulation:
 

--- a/src/core/settings.test.ts
+++ b/src/core/settings.test.ts
@@ -15,7 +15,7 @@ afterEach(async () => {
 });
 
 test('saves valid settings to file', async () => {
-  tmpFile = join(tmpdir(), `settings-${Date.now()}.json`);
+  tmpFile = join(process.cwd(), `settings-${Date.now()}.json`);
   process.env.SETTINGS_FILE = tmpFile;
 
   const input: Settings = {
@@ -33,8 +33,22 @@ test('saves valid settings to file', async () => {
 });
 
 test('returns error for invalid settings', async () => {
-  tmpFile = join(tmpdir(), `settings-${Date.now()}-invalid.json`);
+  tmpFile = join(process.cwd(), `settings-${Date.now()}-invalid.json`);
   process.env.SETTINGS_FILE = tmpFile;
   const result = await saveSettings({ chainId: 0 });
+  expect(result.success).toBe(false);
+});
+
+test('rejects paths outside allowed directory', async () => {
+  tmpFile = join(tmpdir(), `settings-${Date.now()}.json`);
+  process.env.SETTINGS_FILE = tmpFile;
+  const input: Settings = {
+    chainId: 1,
+    rpcUrl: 'http://localhost',
+    minProfitUsd: 1,
+    slippageBps: 10,
+    gasUnits: '21000'
+  };
+  const result = await saveSettings(input);
   expect(result.success).toBe(false);
 });


### PR DESCRIPTION
## Summary
- restrict SETTINGS_FILE to within project root and create directories on save
- test path restrictions and invalid input
- document SETTINGS_FILE usage in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897f271ecb4832abeab3e427493e927