### PR TITLE
Add auth and rate limiting middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "dotenv": "^17.2.1",
         "ethers": "^6.15.0",
         "express": "^5.1.0",
+        "express-rate-limit": "^6.11.2",
         "pino": "^9.8.0",
         "prom-client": "^15.1.3",
         "react": "^19.1.1",
@@ -3836,6 +3837,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.11.2.tgz",
+      "integrity": "sha512-a7uwwfNTh1U60ssiIkuLFWHt4hAC5yxlLGU2VP0X4YNlyEDZAqF4tK3GD3NSitVBrCQmQ0++0uOyFOgC2y4DDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
       }
     },
     "node_modules/express/node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^17.2.1",
     "ethers": "^6.15.0",
     "express": "^5.1.0",
+    "express-rate-limit": "^6.11.2",
     "pino": "^9.8.0",
     "prom-client": "^15.1.3",
     "react": "^19.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.1.0
+      express-rate-limit:
+        specifier: ^6.11.2
+        version: 6.11.2(express@5.1.0)
       pino:
         specifier: ^9.8.0
         version: 9.8.0
@@ -1267,6 +1270,12 @@ packages:
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@6.11.2:
+    resolution: {integrity: sha512-a7uwwfNTh1U60ssiIkuLFWHt4hAC5yxlLGU2VP0X4YNlyEDZAqF4tK3GD3NSitVBrCQmQ0++0uOyFOgC2y4DDw==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      express: ^4 || ^5
 
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
@@ -3473,6 +3482,10 @@ snapshots:
   eventemitter3@5.0.1: {}
 
   expect-type@1.2.2: {}
+
+  express-rate-limit@6.11.2(express@5.1.0):
+    dependencies:
+      express: 5.1.0
 
   express@5.1.0:
     dependencies:

--- a/server/__tests__/api.test.ts
+++ b/server/__tests__/api.test.ts
@@ -75,16 +75,25 @@ describe('API endpoints', () => {
   });
 
   test('POST /api/candidates returns candidates list', async () => {
-    const res = await request(app).post('/api/candidates').send(baseParams);
+    const res = await request(app)
+      .post('/api/candidates')
+      .set('Authorization', 'Bearer t')
+      .send(baseParams);
     expect(res.status).toBe(200);
     const parsed = candidatesResponseSchema.parse(res.body);
     expect(parsed.candidates[0]).toMatchObject({ buy: 'A', sell: 'B', profitUsd: 1 });
+  });
+
+  test('POST /api/candidates returns 401 without token', async () => {
+    const res = await request(app).post('/api/candidates').send(baseParams);
+    expect(res.status).toBe(401);
   });
 
   test('POST /api/simulate returns simulation result', async () => {
     const candidate = { buy: 'A', sell: 'B', profitUsd: 1 };
     const res = await request(app)
       .post('/api/simulate')
+      .set('Authorization', 'Bearer t')
       .send({ candidate, params: baseParams });
     expect(res.status).toBe(200);
     const parsed = simulateResponseSchema.parse(res.body);
@@ -104,6 +113,11 @@ describe('API endpoints', () => {
     process.env.BUNDLE_SIGNER_KEY = '0xabc';
     ({ default: app } = await import('../index'));
     const res = await request(app).post('/api/execute').send(execParams);
+    expect(res.status).toBe(401);
+  });
+
+  test('GET /metrics returns 401 without token', async () => {
+    const res = await request(app).get('/metrics');
     expect(res.status).toBe(401);
   });
 

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,0 +1,19 @@
+import type { Request, Response, NextFunction } from "express";
+import { timingSafeEqual } from "crypto";
+
+const AUTH_TOKEN = process.env.AUTH_TOKEN || "";
+
+export function requireAuth(req: Request, res: Response, next: NextFunction) {
+  const provided = req.headers.authorization ?? "";
+  const expected = `Bearer ${AUTH_TOKEN}`;
+  const authorized =
+    AUTH_TOKEN &&
+    provided.length === expected.length &&
+    timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
+
+  if (!authorized) {
+    return res.status(401).json({ error: "unauthorized" });
+  }
+
+  next();
+}


### PR DESCRIPTION
## Summary
- secure candidate, simulation, stream, and metrics endpoints with Bearer token auth
- add express-rate-limit to cap requests per IP
- document new authentication and rate-limiting requirements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897f3a22690832a88fdd5185d77b8bd