### PR TITLE
Protect settings endpoint with auth and validation

### DIFF
--- a/server/__tests__/api.test.ts
+++ b/server/__tests__/api.test.ts
@@ -46,6 +46,14 @@ const execParams = {
   dryRun: true,
 };
 
+const settingsParams = {
+  chainId: 1,
+  rpcUrl: 'http://localhost:8545',
+  minProfitUsd: 1,
+  slippageBps: 10,
+  gasUnits: '21000',
+};
+
 describe('API endpoints', () => {
   let app: any;
 
@@ -119,6 +127,19 @@ describe('API endpoints', () => {
   test('GET /metrics returns 401 without token', async () => {
     const res = await request(app).get('/metrics');
     expect(res.status).toBe(401);
+  });
+
+  test('POST /api/settings returns 401 without token', async () => {
+    const res = await request(app).post('/api/settings').send(settingsParams);
+    expect(res.status).toBe(401);
+  });
+
+  test('POST /api/settings returns 400 with invalid payload', async () => {
+    const res = await request(app)
+      .post('/api/settings')
+      .set('Authorization', 'Bearer t')
+      .send({ ...settingsParams, chainId: 0 });
+    expect(res.status).toBe(400);
   });
 
   test('POST /api/execute processes request when enabled', async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,8 +6,17 @@ import { requireAuth } from "./middleware/auth";
 import { fetchCandidates } from "../src/core/candidates";
 import { simulateCandidate, type SimulateCandidateParams } from "../src/core/arbitrage";
 import { saveSettings } from "../src/core/settings";
-import type { CandidateParamsInput, CandidatesRequest, SimulateRequest } from "./schemas";
-import { candidatesRequestSchema, simulateRequestSchema } from "./schemas";
+import type {
+  CandidateParamsInput,
+  CandidatesRequest,
+  SimulateRequest,
+  SettingsRequest,
+} from "./schemas";
+import {
+  candidatesRequestSchema,
+  simulateRequestSchema,
+  settingsRequestSchema,
+} from "./schemas";
 import type { Candidate } from "../src/core/candidates";
 import { stream } from "./stream";
 import { execute } from "./routes/execute";
@@ -101,9 +110,16 @@ app.post("/api/simulate", requireAuth, validateBody(wrap<SimulateRequest>(simula
 
 app.post("/api/execute", execute);
 
-app.post("/api/settings", async (req, res) => {
-  res.json(await saveSettings(req.body));
-});
+app.post(
+  "/api/settings",
+  requireAuth,
+  validateBody(wrap<SettingsRequest>(settingsRequestSchema)),
+  async (req, res) => {
+    // @ts-expect-error injected
+    const body = req.parsed;
+    res.json(await saveSettings(body));
+  }
+);
 
 export function buildSimulateParams(body: CandidateParamsInput, candidate: Candidate): SimulateCandidateParams {
   const provider = getProvider(body.providerUrl);

--- a/server/schemas.ts
+++ b/server/schemas.ts
@@ -20,6 +20,14 @@ export const simulateResponseSchema = candidateSchema;
 export const executeRequestSchema = CandidatesInput;
 export const executeResponseSchema = z.object({ ok: z.boolean() });
 
+export const settingsRequestSchema = z.object({
+  chainId: z.number().int().positive(),
+  rpcUrl: z.string().url(),
+  minProfitUsd: z.number().positive(),
+  slippageBps: z.number().min(0).max(2000),
+  gasUnits: z.string().regex(/^\d+$/),
+});
+
 export type CandidateInput = z.infer<typeof candidateSchema>;
 export type CandidateParamsInput = TCandidatesInput;
 export type CandidatesRequest = z.infer<typeof candidatesRequestSchema>;
@@ -28,4 +36,5 @@ export type SimulateRequest = z.infer<typeof simulateRequestSchema>;
 export type SimulateResponse = z.infer<typeof simulateResponseSchema>;
 export type ExecuteRequest = z.infer<typeof executeRequestSchema>;
 export type ExecuteResponse = z.infer<typeof executeResponseSchema>;
+export type SettingsRequest = z.infer<typeof settingsRequestSchema>;
 export type TokenInput = z.infer<typeof TokenSchema>;


### PR DESCRIPTION
## Summary
- secure `/api/settings` with authentication and schema validation
- add Settings schema and types
- test settings endpoint for unauthorized and invalid payloads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897f88673ec832aafdb7de127a760ba