### PR TITLE
Add CORS middleware and JSON payload limit

### DIFF
--- a/server/__tests__/api.test.ts
+++ b/server/__tests__/api.test.ts
@@ -142,6 +142,15 @@ describe('API endpoints', () => {
     expect(res.status).toBe(400);
   });
 
+  test('POST /api/candidates rejects oversized payload', async () => {
+    const bigPayload = { ...baseParams, filler: 'a'.repeat(1024 * 1024 * 2) };
+    const res = await request(app)
+      .post('/api/candidates')
+      .set('Authorization', 'Bearer t')
+      .send(bigPayload);
+    expect(res.status).toBe(413);
+  });
+
   test('POST /api/execute processes request when enabled', async () => {
     vi.resetModules();
     vi.doMock('../../src/core/candidates', () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import cors from "cors";
 import { JsonRpcProvider } from "ethers";
 import rateLimit from "express-rate-limit";
 import { validateBody } from "./middleware/validate";
@@ -88,7 +89,8 @@ const wrap = <T>(schema: { safeParse: (v: unknown) => { success: boolean; data?:
 };
 
 const app = express();
-app.use(express.json());
+app.use(cors({ origin: ["http://localhost:3000"] }));
+app.use(express.json({ limit: "1mb" }));
 
 // Global rate limiter
 app.use(


### PR DESCRIPTION
## Summary
- allow requests from the frontend via CORS and cap JSON bodies at 1 MB
- test that oversized requests are rejected with 413

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897fc7015e4832aacc7fbdd435fc49d