### PR TITLE
Add Flashbots relay fetch timeout and tests

### DIFF
--- a/tests/relays/flashbots.spec.ts
+++ b/tests/relays/flashbots.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import http from "node:http";
+import { FlashbotsRelay } from "../../src/exec/relays/flashbots";
+
+describe("FlashbotsRelay", () => {
+  it("times out on slow relay", async () => {
+    vi.useFakeTimers();
+
+    const server = http.createServer((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ result: "0x1" }));
+      }, 15_000);
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as any).port;
+
+    const relay = new FlashbotsRelay({
+      rpcUrl: `http://127.0.0.1:${port}`,
+      bundleSignerKey: "0x" + "11".repeat(32),
+    });
+    (relay as any).signer = {
+      address: "0x" + "22".repeat(20),
+      signTransaction: async () => "0xsigned",
+      signMessage: async () => "0xsignature",
+    };
+
+    const promise = relay.sendPrivateTx({
+      routeCalldata: "0x",
+      maxFeePerGas: 0n,
+      maxPriorityFeePerGas: 0n,
+      deadline: Math.floor(Date.now() / 1000) + 60,
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    const result = await promise;
+    expect(result).toEqual({ ok: false, error: "timeout" });
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    vi.useRealTimers();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add AbortController-based 10s timeout to Flashbots relay fetch
- return `{ ok: false, error: 'timeout' }` when request times out
- test slow relay to ensure timeout behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ff2e0788832aa3fb18405d97f343