### PR TITLE
Enforce WS config when execution enabled

### DIFF
--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect, afterAll } from 'vitest';
+import { loadConfig } from './config';
+
+const originalEnv = process.env;
+
+const baseEnv = {
+  RPC_URL: 'https://example.com',
+  PRIVATE_KEY: '0x' + '1'.repeat(64),
+  MIN_PROFIT_USD: '0',
+  SLIPPAGE_BPS: '0',
+};
+
+function setEnv(overrides: Record<string, string | undefined> = {}) {
+  process.env = { ...baseEnv, ...overrides } as any;
+}
+
+describe('loadConfig', () => {
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test('loads config when execution disabled', async () => {
+    setEnv({ EXEC_ENABLED: '0' });
+    const cfg = await loadConfig();
+    expect(cfg.execEnabled).toBe(false);
+    expect(cfg.wsRpc).toBeUndefined();
+    expect(cfg.bundleSignerKey).toBeUndefined();
+  });
+
+  test('requires WS_RPC when EXEC_ENABLED=1', async () => {
+    setEnv({ EXEC_ENABLED: '1', BUNDLE_SIGNER_KEY: '0x' + '2'.repeat(64) });
+    await expect(loadConfig()).rejects.toThrow('WS_RPC is required when EXEC_ENABLED=1');
+  });
+
+  test('requires BUNDLE_SIGNER_KEY when EXEC_ENABLED=1', async () => {
+    setEnv({ EXEC_ENABLED: '1', WS_RPC: 'ws://localhost:8546' });
+    await expect(loadConfig()).rejects.toThrow('BUNDLE_SIGNER_KEY is required when EXEC_ENABLED=1');
+  });
+
+  test('loads config when EXEC_ENABLED=1 with required variables', async () => {
+    setEnv({
+      EXEC_ENABLED: '1',
+      WS_RPC: 'ws://localhost:8546',
+      BUNDLE_SIGNER_KEY: '0x' + '2'.repeat(64),
+    });
+    const cfg = await loadConfig();
+    expect(cfg.execEnabled).toBe(true);
+    expect(cfg.wsRpc).toBe('ws://localhost:8546');
+    expect(cfg.bundleSignerKey).toBe('0x' + '2'.repeat(64));
+  });
+});
+

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,17 +3,29 @@ import { z } from 'zod';
 
 dotenv.config();
 
-const schema = z.object({
-  RPC_URL: z.string().url(),
-  PRIVATE_KEY: z.string().regex(/^0x[0-9a-fA-F]{64}$/),
-  CHAIN_ID: z.coerce.number().int().positive().default(1),
-  MIN_PROFIT_USD: z.coerce.number().nonnegative(),
-  SLIPPAGE_BPS: z.coerce.number().int().nonnegative(),
-  AUTH_TOKEN: z.string().optional(),
-  EXEC_ENABLED: z.enum(['0', '1']).optional(),
-  WS_RPC: z.string().url().optional(),
-  BUNDLE_SIGNER_KEY: z.string().regex(/^0x[0-9a-fA-F]{64}$/).optional()
-});
+const schema = z
+  .object({
+    RPC_URL: z.string().url(),
+    PRIVATE_KEY: z.string().regex(/^0x[0-9a-fA-F]{64}$/),
+    CHAIN_ID: z.coerce.number().int().positive().default(1),
+    MIN_PROFIT_USD: z.coerce.number().nonnegative(),
+    SLIPPAGE_BPS: z.coerce.number().int().nonnegative(),
+    AUTH_TOKEN: z.string().optional(),
+    EXEC_ENABLED: z.enum(['0', '1']).optional(),
+    WS_RPC: z.string().url().optional(),
+    BUNDLE_SIGNER_KEY: z
+      .string()
+      .regex(/^0x[0-9a-fA-F]{64}$/)
+      .optional(),
+  })
+  .refine(env => env.EXEC_ENABLED !== '1' || env.WS_RPC, {
+    message: 'WS_RPC is required when EXEC_ENABLED=1',
+    path: ['WS_RPC'],
+  })
+  .refine(env => env.EXEC_ENABLED !== '1' || env.BUNDLE_SIGNER_KEY, {
+    message: 'BUNDLE_SIGNER_KEY is required when EXEC_ENABLED=1',
+    path: ['BUNDLE_SIGNER_KEY'],
+  });
 
 export type Config = {
   rpcUrl: string;


### PR DESCRIPTION
## Summary
- require WS_RPC and BUNDLE_SIGNER_KEY when EXEC_ENABLED=1
- add unit tests for config loading combinations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689802edd5c0832aa263f616beb4a9e2