### PR TITLE
Apply middleware to execute route

### DIFF
--- a/server/__tests__/api.test.ts
+++ b/server/__tests__/api.test.ts
@@ -109,7 +109,10 @@ describe('API endpoints', () => {
   });
 
   test('POST /api/execute returns 403 when disabled', async () => {
-    const res = await request(app).post('/api/execute').send(execParams);
+    const res = await request(app)
+      .post('/api/execute')
+      .set('Authorization', 'Bearer t')
+      .send(execParams);
     expect(res.status).toBe(403);
   });
 
@@ -122,6 +125,20 @@ describe('API endpoints', () => {
     ({ default: app } = await import('../index'));
     const res = await request(app).post('/api/execute').send(execParams);
     expect(res.status).toBe(401);
+  });
+
+  test('POST /api/execute returns 400 with invalid payload', async () => {
+    vi.resetModules();
+    process.env.EXEC_ENABLED = '1';
+    process.env.AUTH_TOKEN = 't';
+    process.env.WS_RPC = 'ws://localhost';
+    process.env.BUNDLE_SIGNER_KEY = '0xabc';
+    ({ default: app } = await import('../index'));
+    const res = await request(app)
+      .post('/api/execute')
+      .set('Authorization', 'Bearer t')
+      .send({ routeCalldata: '0x' });
+    expect(res.status).toBe(400);
   });
 
   test('GET /metrics returns 401 without token', async () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -22,6 +22,7 @@ import {
 import type { Candidate } from "../src/core/candidates";
 import { stream } from "./stream";
 import { execute } from "./routes/execute";
+import { vSafe, ExecuteInput } from "../src/shared/validation/valibot-schemas";
 import { register } from "../src/utils/metrics";
 
 interface CachedProvider {
@@ -148,7 +149,7 @@ app.post("/api/simulate", requireAuth, validateBody(wrap<SimulateRequest>(simula
   res.json(await simulateCandidate(params));
 });
 
-app.post("/api/execute", execute);
+app.post("/api/execute", requireAuth, validateBody((v) => vSafe(ExecuteInput, v)), execute);
 
 app.post(
   "/api/settings",

--- a/server/routes/execute.ts
+++ b/server/routes/execute.ts
@@ -1,12 +1,8 @@
 import type { Request, Response } from "express";
-import { timingSafeEqual } from "crypto";
-import { vSafe, ExecuteInput } from "../../src/shared/validation/valibot-schemas";
 import { executeWithRelay } from "../../src/exec/submit";
 import { FlashbotsRelay } from "../../src/exec/relays/flashbots";
 
 const EXEC_ENABLED = process.env.EXEC_ENABLED === "1";
-const AUTH_TOKEN = process.env.AUTH_TOKEN || "";
-
 let relay: FlashbotsRelay;
 function getRelay(): FlashbotsRelay {
   if (!relay) {
@@ -21,19 +17,8 @@ function getRelay(): FlashbotsRelay {
 export async function execute(req: Request, res: Response) {
   if (!EXEC_ENABLED) return res.status(403).json({ error: "execution disabled" });
 
-  const provided = req.headers.authorization ?? "";
-  const expected = `Bearer ${AUTH_TOKEN}`;
-  const authorized =
-    AUTH_TOKEN &&
-    provided.length === expected.length &&
-    timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
-
-  if (!authorized) {
-    return res.status(401).json({ error: "unauthorized" });
-  }
-
-  const r = vSafe(ExecuteInput, req.body);
-  if (!r.success) return res.status(400).json({ error: r.error });
+  // @ts-expect-error injected by validateBody middleware
+  const body = req.parsed as any;
 
   let rel: FlashbotsRelay;
   try {
@@ -44,9 +29,9 @@ export async function execute(req: Request, res: Response) {
   }
 
   const out = await executeWithRelay(rel, {
-    ...r.data,
-    maxFeePerGas: BigInt(r.data.maxFeePerGas),
-    maxPriorityFeePerGas: BigInt(r.data.maxPriorityFeePerGas)
+    ...body,
+    maxFeePerGas: BigInt(body.maxFeePerGas),
+    maxPriorityFeePerGas: BigInt(body.maxPriorityFeePerGas),
   } as any);
 
   res.status(out.ok ? 200 : 500).json(out);


### PR DESCRIPTION
## Summary
- secure `/api/execute` with `requireAuth` and body validation middleware
- simplify execute route by removing inline auth and using parsed request
- extend API tests to cover new middleware behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689804cc6dbc832a93a9268a028587ee