### PR TITLE
feat: track active sse clients

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -171,6 +171,7 @@ export {
   successCounter,
   failureCounter,
   gasCounter,
+  activeSseClients,
   register as metricsRegistry
 } from './src/utils/metrics';
 export { checkAllowances };

--- a/server/__tests__/stream.test.ts
+++ b/server/__tests__/stream.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test, vi } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import request from 'supertest';
+
+const metricName = 'sse_clients_active';
+
+describe('SSE client metrics', () => {
+  test('increments and exposes active client gauge', async () => {
+    vi.resetModules();
+    process.env.AUTH_TOKEN = 't';
+    const { default: app } = await import('../index');
+    const { register } = await import('../../src/utils/metrics');
+    const server = app.listen(0);
+
+    try {
+      const port = (server.address() as AddressInfo).port;
+      const sreq = http.get({
+        hostname: '127.0.0.1',
+        port,
+        path: '/api/stream',
+        headers: { Authorization: 'Bearer t' }
+      });
+
+      await new Promise(resolve => sreq.once('response', resolve));
+      await new Promise(r => setTimeout(r, 10));
+
+      const metric = register.getSingleMetric(metricName);
+      expect(metric?.hashMap['']?.value).toBe(1);
+
+      sreq.destroy();
+      await new Promise(r => setTimeout(r, 10));
+      expect(register.getSingleMetric(metricName)?.hashMap['']?.value).toBe(0);
+
+      const res = await request(server)
+        .get('/metrics')
+        .set('Authorization', 'Bearer t');
+      expect(res.status).toBe(200);
+      expect(res.text).toMatch(metricName);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/server/stream.ts
+++ b/server/stream.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import { eventBus } from "../src/core/bus";
+import { activeSseClients } from "../src/utils/metrics";
 
 const HEARTBEAT_MS = 15_000;
 
@@ -9,6 +10,8 @@ export function stream(req: Request, res: Response) {
   res.setHeader("Connection", "keep-alive");
   // flush headers to establish SSE with client
   res.flushHeaders?.();
+
+  activeSseClients.inc();
 
   const push = (type: string, data: unknown) =>
     res.write(`event: ${type}\ndata:${JSON.stringify(data)}\n\n`);
@@ -28,5 +31,6 @@ export function stream(req: Request, res: Response) {
     eventBus.off("candidate", onCand);
     eventBus.off("log", onLog);
     eventBus.off("block", onBlock);
+    activeSseClients.dec();
   });
 }

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -1,4 +1,4 @@
-import { Counter, Registry } from 'prom-client';
+import { Counter, Gauge, Registry } from 'prom-client';
 
 /** Central registry for all application metrics */
 export const register = new Registry();
@@ -21,5 +21,12 @@ export const failureCounter = new Counter({
 export const gasCounter = new Counter({
   name: 'trade_gas_used_total',
   help: 'Total gas consumed by trades',
+  registers: [register]
+});
+
+/** Tracks current number of connected SSE clients */
+export const activeSseClients = new Gauge({
+  name: 'sse_clients_active',
+  help: 'Number of active SSE clients',
   registers: [register]
 });


### PR DESCRIPTION
## Summary
- add `sse_clients_active` gauge to metrics registry
- increment and decrement gauge on SSE stream connections
- test and expose gauge via `/metrics` endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689806500a24832abcc0aa521bcdd1cc