### PR TITLE
feat: add health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,11 @@ await main({
   minProfitUsd: 5
 });
 HTTP API
-The server exposes HTTP endpoints for candidate discovery, simulation, execution, and streaming updates. All endpoints require
-a valid `Authorization: Bearer $AUTH_TOKEN` header and are rate-limited to 100 requests per minute per IP.
+The server exposes HTTP endpoints for candidate discovery, simulation, execution, streaming updates, and health checks. All endpoints require
+a valid `Authorization: Bearer $AUTH_TOKEN` header and are rate-limited to 100 requests per minute per IP unless noted otherwise.
+
+### `GET /healthz`
+Basic health check endpoint. Returns `ok` when the server is running. If `RPC_URL` is set, the server will verify connectivity before responding. No authentication is required.
 
 ### `POST /api/candidates`
 Returns a list of potential arbitrage trades.

--- a/server/index.ts
+++ b/server/index.ts
@@ -115,6 +115,19 @@ app.use(
   })
 );
 
+// Health check endpoint
+app.get("/healthz", async (_req, res) => {
+  try {
+    const url = process.env.RPC_URL;
+    if (url) {
+      await getProvider(url).getBlockNumber();
+    }
+    res.send("ok");
+  } catch {
+    res.status(500).send("error");
+  }
+});
+
 // Server-Sent Events stream for candidates and logs
 app.get("/api/stream", requireAuth, stream);
 


### PR DESCRIPTION
## Summary
- expose `/healthz` for basic server health checks
- document `/healthz` endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689807c8b7c4832a96cc65a735f16b42