### PR TITLE
chore: configure tsconfig paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,11 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "#server/*": ["server/*"]
+    },
     "jsx": "react-jsx",
     "types": ["vite/client", "react", "react-dom"],
     "strict": true,
@@ -17,6 +22,6 @@
     "sourceMap": true,
     "noEmit": true
   },
-  "include": ["src", "vite-env.d.ts"]
+  "include": ["src", "server", "tests", "vite-env.d.ts"]
 }
 


### PR DESCRIPTION
## Summary
- add TypeScript base URL and path aliases for src and server
- expand TypeScript include paths for server and tests

## Testing
- `npm test` *(fails: parse failures and failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68984339b354832aaf44fc23c042fe89