### PR TITLE
refactor: replace relative imports with aliases

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env ts-node
 import { JsonRpcProvider } from 'ethers';
 import dotenv from 'dotenv';
-import { toQ96 } from './src/utils/fixed';
-import { buildCandidates, simulateCandidate } from './src/core/arbitrage';
-import type { VenueConfig } from './src/core/candidates';
+import { toQ96 } from '@/utils/fixed';
+import { buildCandidates, simulateCandidate } from '@/core/arbitrage';
+import type { VenueConfig } from '@/core/candidates';
 
 dotenv.config();
 

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,12 @@
-import type { CandidateParams, Candidate } from './src/core/candidates';
+import type { CandidateParams, Candidate } from '@/core/candidates';
 import {
   buildCandidates as buildArbCandidates,
   simulateCandidate as simulateArbCandidate
-} from './src/core/arbitrage';
-import { checkSlippage as slippageGuard } from './src/risk/slippage';
-import { logger } from './src/utils/logger';
+} from '@/core/arbitrage';
+import { checkSlippage as slippageGuard } from '@/risk/slippage';
+import { logger } from '@/utils/logger';
 import { Contract } from 'ethers';
-import { successCounter, failureCounter, gasCounter } from './src/utils/metrics';
+import { successCounter, failureCounter, gasCounter } from '@/utils/metrics';
 
 /**
  * Simple readiness check ensuring token allowances are configured.
@@ -149,30 +149,30 @@ export {
   simulateV2Swap,
   submitV2Swap,
   quoteOutV2
-} from './src/core/v2';
+} from '@/core/v2';
 export {
   getV3Quote,
   simulateV3Swap,
   submitV3Swap
-} from './src/core/v3';
-export { fetchCandidates } from './src/core/candidates';
-export { buildCandidates, simulateCandidate } from './src/core/arbitrage';
-export { buildStrategy } from './src/core/strategy';
+} from '@/core/v3';
+export { fetchCandidates } from '@/core/candidates';
+export { buildCandidates, simulateCandidate } from '@/core/arbitrage';
+export { buildStrategy } from '@/core/strategy';
 export {
   checkSlippage,
   calcMinOut,
   computeSlippageAdjustedOut,
   DEFAULT_SLIPPAGE_BPS,
   DEFAULT_SLIPPAGE
-} from './src/risk/slippage';
-export { checkGuards } from './src/risk/guards';
-export { logger, withTrade } from './src/utils/logger';
+} from '@/risk/slippage';
+export { checkGuards } from '@/risk/guards';
+export { logger, withTrade } from '@/utils/logger';
 export {
   successCounter,
   failureCounter,
   gasCounter,
   activeSseClients,
   register as metricsRegistry
-} from './src/utils/metrics';
+} from '@/utils/metrics';
 export { checkAllowances };
 export default main;

--- a/scripts/buildRegistry.ts
+++ b/scripts/buildRegistry.ts
@@ -1,7 +1,7 @@
 import { createPublicClient, http, getAddress } from "viem";
 import { mainnet } from "viem/chains";
 import fs from "node:fs";
-import tokens from "../src/chain/tokens.mainnet.json" assert { type: "json" };
+import tokens from "@/chain/tokens.mainnet.json" assert { type: "json" };
 
 const client = createPublicClient({ chain: mainnet, transport: http(process.env.HTTP_RPC || `https://mainnet.infura.io/v3/${process.env.INFURA_PROJECT_ID}`) });
 

--- a/server/__tests__/api.test.ts
+++ b/server/__tests__/api.test.ts
@@ -61,13 +61,13 @@ describe('API endpoints', () => {
     vi.resetModules();
     delete process.env.EXEC_ENABLED;
     process.env.AUTH_TOKEN = 't';
-    vi.doMock('../../src/core/candidates', () => {
+    vi.doMock('@/core/candidates', () => {
       const fetchCandidates = vi.fn(async () => [
         { buy: 'A', sell: 'B', profitUsd: 1 },
       ]);
       return { __esModule: true, fetchCandidates, default: { fetchCandidates } };
     });
-    vi.doMock('../../src/core/arbitrage', () => {
+    vi.doMock('@/core/arbitrage', () => {
       const simulateCandidate = vi.fn(async () => ({
         buy: 'A',
         sell: 'B',
@@ -170,11 +170,11 @@ describe('API endpoints', () => {
 
   test('POST /api/execute processes request when enabled', async () => {
     vi.resetModules();
-    vi.doMock('../../src/core/candidates', () => {
+    vi.doMock('@/core/candidates', () => {
       const fetchCandidates = vi.fn(async () => []);
       return { __esModule: true, fetchCandidates, default: { fetchCandidates } };
     });
-    vi.doMock('../../src/core/arbitrage', () => {
+    vi.doMock('@/core/arbitrage', () => {
       const simulateCandidate = vi.fn(async () => ({}));
       return { __esModule: true, simulateCandidate, default: { simulateCandidate } };
     });

--- a/server/__tests__/stream.test.ts
+++ b/server/__tests__/stream.test.ts
@@ -10,7 +10,7 @@ describe('SSE client metrics', () => {
     vi.resetModules();
     process.env.AUTH_TOKEN = 't';
     const { default: app } = await import('../index');
-    const { register } = await import('../../src/utils/metrics');
+    const { register } = await import('@/utils/metrics');
     const server = app.listen(0);
 
     try {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1,8 +1,8 @@
 import { expect, expectTypeOf, test, beforeAll } from 'vitest';
 import { JsonRpcProvider } from 'ethers';
-import type { Candidate } from '../src/core/candidates';
+import type { Candidate } from '@/core/candidates';
 import type { CandidateParamsInput } from './schemas';
-import type { SimulateCandidateParams } from '../src/core/arbitrage';
+import type { SimulateCandidateParams } from '@/core/arbitrage';
 
 let buildSimulateParams: (body: CandidateParamsInput, candidate: Candidate) => SimulateCandidateParams;
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,10 +4,10 @@ import { JsonRpcProvider } from "ethers";
 import rateLimit from "express-rate-limit";
 import { validateBody } from "./middleware/validate";
 import { requireAuth } from "./middleware/auth";
-import { fetchCandidates } from "../src/core/candidates";
-import { simulateCandidate, type SimulateCandidateParams } from "../src/core/arbitrage";
-import { saveSettings } from "../src/core/settings";
-import { logger } from "../src/utils/logger";
+import { fetchCandidates } from "@/core/candidates";
+import { simulateCandidate, type SimulateCandidateParams } from "@/core/arbitrage";
+import { saveSettings } from "@/core/settings";
+import { logger } from "@/utils/logger";
 import type {
   CandidateParamsInput,
   CandidatesRequest,
@@ -19,11 +19,11 @@ import {
   simulateRequestSchema,
   settingsRequestSchema,
 } from "./schemas";
-import type { Candidate } from "../src/core/candidates";
+import type { Candidate } from "@/core/candidates";
 import { stream } from "./stream";
 import { execute } from "./routes/execute";
-import { vSafe, ExecuteInput } from "../src/shared/validation/valibot-schemas";
-import { register } from "../src/utils/metrics";
+import { vSafe, ExecuteInput } from "@/shared/validation/valibot-schemas";
+import { register } from "@/utils/metrics";
 
 interface CachedProvider {
   provider: JsonRpcProvider;

--- a/server/routes/execute.ts
+++ b/server/routes/execute.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
-import { executeWithRelay } from "../../src/exec/submit";
-import { FlashbotsRelay } from "../../src/exec/relays/flashbots";
+import { executeWithRelay } from "@/exec/submit";
+import { FlashbotsRelay } from "@/exec/relays/flashbots";
 
 const EXEC_ENABLED = process.env.EXEC_ENABLED === "1";
 let relay: FlashbotsRelay;

--- a/server/schemas.ts
+++ b/server/schemas.ts
@@ -5,7 +5,7 @@ import {
   SimulateInput,
   TCandidatesInput,
   TokenSchema,
-} from '../src/shared/validation';
+} from '@/shared/validation';
 
 export const candidateSchema = CandidateSchema;
 

--- a/server/stream.ts
+++ b/server/stream.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
-import { eventBus } from "../src/core/bus";
-import { activeSseClients } from "../src/utils/metrics";
+import { eventBus } from "@/core/bus";
+import { activeSseClients } from "@/utils/metrics";
 
 const HEARTBEAT_MS = 15_000;
 

--- a/tests/perf/loop.spec.ts
+++ b/tests/perf/loop.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { runLoop } from "../../src/core/strategy";
-import { normalizeStartup } from "../../src/core/context";
+import { runLoop } from "@/core/strategy";
+import { normalizeStartup } from "@/core/context";
 
 describe("loop perf (sanity)", () => {
   it("runs a couple of iterations quickly", async () => {

--- a/tests/relays/flashbots.spec.ts
+++ b/tests/relays/flashbots.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import http from "node:http";
-import { FlashbotsRelay } from "../../src/exec/relays/flashbots";
+import { FlashbotsRelay } from "@/exec/relays/flashbots";
 
 describe("FlashbotsRelay", () => {
   it("times out on slow relay", async () => {

--- a/tests/validation/candidates.spec.ts
+++ b/tests/validation/candidates.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { CandidatesInput, vParse, vSafe } from "../../src/shared/validation/valibot-schemas";
+import { CandidatesInput, vParse, vSafe } from "@/shared/validation/valibot-schemas";
 
 describe("CandidatesInput", () => {
   it("accepts a valid payload", () => {

--- a/tests/workers/guards.spec.ts
+++ b/tests/workers/guards.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { asReserveSnapshot, isBigintStr } from "../../src/workers/guards";
+import { asReserveSnapshot, isBigintStr } from "@/workers/guards";
 
 describe("worker guards", () => {
   it("maps reserve snapshot", () => {


### PR DESCRIPTION
## Summary
- switch CLI and main entry imports to `@/` alias
- rewrite server modules and tests to use alias-based imports
- update scripts and mocks to reference `@/` paths

## Testing
- `npm test` *(fails: Transform failed with 1 error: server/index.ts:87:36)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: src/vite-env.d.ts:1:13 error TS1005: '>' expected)*

------
https://chatgpt.com/codex/tasks/task_e_6898446f9484832aa5a25b3b06c5b389