### PR TITLE
test(cli): check output streams

### DIFF
--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -23,6 +23,6 @@ describe("cli", () => {
       { encoding: "utf-8" }
     );
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("Invalid venues JSON");
+    expect((result.stderr ?? "") + (result.stdout ?? "")).toContain("Invalid venues JSON");
   });
 });


### PR DESCRIPTION
## Summary
- ensure CLI invalid venues JSON test searches both stderr and stdout

## Testing
- `npm test` *(fails: Transform failed in server/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689846a67728832a80bdb4d2ca6817f7