### PR TITLE
feat: add path containment helper

### DIFF
--- a/src/core/settings.test.ts
+++ b/src/core/settings.test.ts
@@ -2,7 +2,7 @@ import { afterEach, expect, test } from 'vitest';
 import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { saveSettings, type Settings } from './settings';
+import { saveSettings, type Settings, isInside } from './settings';
 
 let tmpFile: string | null = null;
 
@@ -51,4 +51,16 @@ test('rejects paths outside allowed directory', async () => {
   };
   const result = await saveSettings(input);
   expect(result.success).toBe(false);
+});
+
+test('isInside identifies paths within base directory', () => {
+  const base = process.cwd();
+  const target = join(base, 'foo', 'bar.txt');
+  expect(isInside(base, target)).toBe(true);
+});
+
+test('isInside rejects paths outside base directory', () => {
+  const base = process.cwd();
+  const target = join(base, '..', 'bar.txt');
+  expect(isInside(base, target)).toBe(false);
 });

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -17,6 +17,11 @@ export type Settings = z.infer<typeof settingsSchema>;
 const baseDir = path.resolve(__dirname, "../../");
 const defaultFile = path.join(baseDir, "settings.json");
 
+export function isInside(baseDir: string, target: string): boolean {
+  const relative = path.relative(path.resolve(baseDir), path.resolve(target));
+  return !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
 export async function saveSettings(
   input: unknown
 ): Promise<{ success: true; data: Settings } | { success: false; error: string }> {
@@ -28,7 +33,7 @@ export async function saveSettings(
   }
   const filePath = path.resolve(process.env.SETTINGS_FILE ?? defaultFile);
   // Ensure the resolved file path stays within the allowed base directory.
-  if (path.relative(baseDir, filePath).startsWith("..")) {
+  if (!isInside(baseDir, filePath)) {
     return { success: false, error: "Settings path escapes allowed directory" };
   }
   try {


### PR DESCRIPTION
## Summary
- add reusable `isInside` path helper
- ensure settings files stay within allowed directory
- test `isInside` behavior

## Testing
- `npm test` (fails: Transform failed with 1 error in server/index.ts)
- `npx vitest run src/core/settings.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898486cee50832a99fd5eb69a424130