### PR TITLE
feat: expand esbuild coverage and reorganize vitest projects

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,8 @@ export default defineConfig({
     jsx: 'automatic',
     include: [
       /src\/.*\.(tsx|ts|jsx|js)$/,
-      /server\/.*\.(tsx|ts|jsx|js)$/
+      /server\/.*\.(tsx|ts|jsx|js)$/,
+      /tests\/.*\.(tsx|ts|jsx|js)$/
     ],
     loader: 'tsx'
   },
@@ -29,8 +30,10 @@ export default defineConfig({
     }
   },
   test: {
-    environment: 'node',
-    environmentMatchGlobs: [['src/**', 'jsdom']]
+    projects: [
+      { environment: 'node', include: ['server/**/*.ts', 'tests/**/*.ts'] },
+      { environment: 'jsdom', include: ['src/**/*.ts', 'src/**/*.tsx'] }
+    ]
   }
 })
 


### PR DESCRIPTION
## Summary
- process tests directory with esbuild
- restructure Vitest config using project environments

## Testing
- `npm test` *(fails: Cannot find package '@/core/candidates' imported from '/workspace/redesigned-engine/server/index.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68984ec69a68832aa86bc2ba2863d7b0