### PR TITLE
refactor: replace wrap arrow with function

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -87,10 +87,16 @@ function assertEnv(): void {
 
 assertEnv();
 
-const wrap = <T>(schema: { safeParse: (v: unknown) => { success: boolean; data?: T; error?: { message: string } } }) => (v: unknown) => {
-  const r = schema.safeParse(v);
-  return r.success ? { success: true, data: r.data as T } : { success: false, error: r.error?.message };
-};
+function wrap<T>(schema: {
+  safeParse: (v: unknown) => { success: boolean; data?: T; error?: { message: string } };
+}) {
+  return (v: unknown) => {
+    const r = schema.safeParse(v);
+    return r.success
+      ? { success: true, data: r.data as T }
+      : { success: false, error: r.error?.message };
+  };
+}
 
 const app = express();
 app.use(cors({ origin: ["http://localhost:3000"] }));


### PR DESCRIPTION
## Summary
- replace `wrap` arrow function with typed function to preserve type safety

## Testing
- `npm test` *(fails: Cannot find module '#server/index' etc.)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: src/vite-env.d.ts(1,13): error TS1005: '>' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68985374b334832a8dab86ad39d23f2a