### PR TITLE
require auth token and propagate to SSE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "arbitrage-engine",
       "version": "0.1.0",
       "dependencies": {
+        "@microsoft/fetch-event-source": "^2.0.1",
         "@reduxjs/toolkit": "^2.8.2",
         "@tanstack/react-query": "^5.84.2",
         "@testing-library/dom": "^10.4.1",
@@ -1279,6 +1280,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+      "license": "MIT"
     },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@reduxjs/toolkit": "^2.8.2",
     "@tanstack/react-query": "^5.84.2",
     "@testing-library/dom": "^10.4.1",

--- a/server/__tests__/stream.test.ts
+++ b/server/__tests__/stream.test.ts
@@ -6,6 +6,34 @@ import request from 'supertest';
 const metricName = 'sse_clients_active';
 
 describe('SSE client metrics', () => {
+  test('requires authorization header', async () => {
+    vi.resetModules();
+    process.env.AUTH_TOKEN = 't';
+    const { default: app } = await import('#server/index');
+    const server = app.listen(0);
+
+    try {
+      const port = (server.address() as AddressInfo).port;
+      await new Promise<void>(resolve => {
+        http.get({ hostname: '127.0.0.1', port, path: '/api/stream' }, res => {
+          expect(res.statusCode).toBe(401);
+          res.destroy();
+          resolve();
+        });
+      });
+
+      await new Promise<void>(resolve => {
+        http.get({ hostname: '127.0.0.1', port, path: '/api/stream', headers: { Authorization: 'Bearer t' } }, res => {
+          expect(res.statusCode).toBe(200);
+          res.destroy();
+          resolve();
+        });
+      });
+    } finally {
+      server.close();
+    }
+  });
+
   test('increments and exposes active client gauge', async () => {
     vi.resetModules();
     process.env.AUTH_TOKEN = 't';

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -8,6 +8,7 @@ const baseEnv = {
   PRIVATE_KEY: '0x' + '1'.repeat(64),
   MIN_PROFIT_USD: '0',
   SLIPPAGE_BPS: '0',
+  AUTH_TOKEN: 't',
 };
 
 function setEnv(overrides: Record<string, string | undefined> = {}) {
@@ -25,6 +26,11 @@ describe('loadConfig', () => {
     expect(cfg.execEnabled).toBe(false);
     expect(cfg.wsRpc).toBeUndefined();
     expect(cfg.bundleSignerKey).toBeUndefined();
+  });
+
+  test('requires AUTH_TOKEN', async () => {
+    setEnv({ AUTH_TOKEN: undefined });
+    await expect(loadConfig()).rejects.toThrow('AUTH_TOKEN');
   });
 
   test('requires WS_RPC when EXEC_ENABLED=1', async () => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -10,7 +10,7 @@ const schema = z
     CHAIN_ID: z.coerce.number().int().positive().default(1),
     MIN_PROFIT_USD: z.coerce.number().nonnegative(),
     SLIPPAGE_BPS: z.coerce.number().int().nonnegative(),
-    AUTH_TOKEN: z.string().optional(),
+    AUTH_TOKEN: z.string().min(1),
     EXEC_ENABLED: z.enum(['0', '1']).optional(),
     WS_RPC: z.string().url().optional(),
     BUNDLE_SIGNER_KEY: z
@@ -33,7 +33,7 @@ export type Config = {
   chainId: number;
   minProfitUsd: number;
   slippageBps: number;
-  authToken?: string;
+  authToken: string;
   execEnabled: boolean;
   wsRpc?: string;
   bundleSignerKey?: string;


### PR DESCRIPTION
## Summary
- make AUTH_TOKEN required in config loading and expose authToken as a mandatory string
- stream Authorization headers from frontend via fetch-event-source
- test SSE authorization handling and add dep for fetch-event-source

## Testing
- `npx vitest run --config vite.config.ts` *(fails: Cannot find module '#server/index')*

------
https://chatgpt.com/codex/tasks/task_e_6899151d26d8832aa8a5480e5771d2b5